### PR TITLE
feat: semantic wiki layer with dedicated wiki-keeper sub-agent

### DIFF
--- a/.agents/skills/create-wiki/SKILL.md
+++ b/.agents/skills/create-wiki/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: create-wiki
+description: Maintain `codedna-wiki.md` as the semantic companion to `.codedna` (L0) for CodeDNA projects.
+model: haiku
+preferred-model: haiku
+model-hint: "Use the smallest available model. This task is read-heavy markdown synthesis — Haiku or equivalent (GPT-4o-mini, Gemini Flash, Qwen-turbo). Never use Opus/o3/Pro for wiki-only tasks."
+---
+
+# Create Wiki
+
+Use this skill when the user asks to create, refresh, repair, or extend the project wiki, or when a major structural change means the semantic map is now stale.
+
+## Core idea
+
+This skill follows the `llm-wiki` pattern: the wiki is a persistent compiled knowledge artifact, not a retrieval cache rebuilt from scratch at every question.
+
+For CodeDNA projects:
+
+- `.codedna` is Level 0 structural truth
+- source file docstrings are local truth
+- `codedna-wiki.md` is the semantic synthesis layer
+
+The wiki should explain how the codebase actually hangs together, where the hotspots are, and what an agent should understand before making changes.
+
+---
+
+## Sub-agent dispatch (Claude Code)
+
+**In Claude Code: do not perform wiki work inline.** Spawn the dedicated wiki-keeper sub-agent to keep wiki maintenance isolated from your context window:
+
+```
+Use the Agent tool with subagent_type="codedna-wiki-keeper"
+```
+
+The wiki-keeper runs on a lightweight model (Haiku), isolates all wiki reads from the caller's context, and returns a compact summary when done.
+
+Use the wiki-keeper for:
+- Refreshing or updating `codedna-wiki.md` after refactors or architecture changes
+- Reading and summarizing the codebase at a high level
+- Answering onboarding questions using the wiki as the primary source
+
+Pass the task as a clear prompt, for example:
+- `"Refresh codedna-wiki.md — a major refactor just landed in codedna_tool/cli.py"`
+- `"Read codedna-wiki.md and summarize the architecture for onboarding"`
+- `"Update the hotspots section — we just added the wiki subcommand"`
+
+If the `.claude/agents/codedna-wiki-keeper.md` file is missing, run `codedna wiki` first to scaffold it.
+
+---
+
+## Direct workflow (Codex, OpenCode, other runtimes)
+
+When sub-agent spawning is not available, perform wiki work directly using this workflow.
+
+### Inputs
+
+Read in this order:
+
+1. `.codedna`
+2. `.planning/codebase/*.md` when available
+3. `README.md`, `SPEC.md`, `QUICKSTART.md`, `AGENTS.md` when relevant
+4. only the module docstrings or focused files needed for the current update
+
+### Output
+
+Update exactly one semantic artifact:
+
+- `codedna-wiki.md`
+
+### Rules
+
+- Treat `.codedna` as authoritative for package structure and session history
+- Do not invent structural relationships that contradict `.codedna`
+- Do not dump raw file inventories into the wiki unless they help navigation
+- Prefer semantic synthesis: workflows, subsystem boundaries, contradictions, hotspots, and maintenance cues
+- If `.planning/codebase/` exists, use it as intermediate context but keep `codedna-wiki.md` shorter and higher-signal
+- Preserve any explicit "open questions", "contradictions", or "maintenance hotspots" sections
+- When you discover drift between L0 and the semantic view, call it out explicitly
+
+### Recommended structure for `codedna-wiki.md`
+
+- Project identity
+- Relationship to L0 (`.codedna`)
+- Semantic topology
+- Operational workflows
+- Testing and validation model
+- Hotspots and likely drift
+- Refresh protocol
+
+### Update workflow
+
+1. Re-read `.codedna`
+2. Re-read `.planning/codebase/*.md` if present
+3. Inspect only the files needed to refresh the affected semantic sections
+4. Update `codedna-wiki.md`
+5. Make sure the wiki still complements `.codedna` instead of duplicating it
+
+### When to refresh
+
+- after `codedna init` on a repo
+- after major refactors
+- after architecture or CLI workflow changes
+- after generating or refreshing `.planning/codebase/`
+- when a user asks for onboarding, architecture explanation, or a repo map

--- a/.claude/agents/codedna-wiki-keeper.md
+++ b/.claude/agents/codedna-wiki-keeper.md
@@ -1,0 +1,85 @@
+---
+name: codedna-wiki-keeper
+description: "Dedicated wiki maintenance agent for CodeDNA projects. Spawn this agent when any of the following occur: (1) user asks to read, summarize, refresh, or update codedna-wiki.md; (2) codedna init or codedna wiki just ran; (3) a major refactor or architecture change landed; (4) .planning/codebase/ was regenerated. This agent reads .codedna and relevant files, then updates codedna-wiki.md in isolation — keeping wiki maintenance out of the main agent's context window.\n\n<example>\nContext: User ran codedna init and wants the wiki updated.\nuser: \"refresh the project wiki after this refactor\"\nassistant: \"Spawning the codedna-wiki-keeper agent to update codedna-wiki.md in an isolated context.\"\n<commentary>\nWiki work is delegated to codedna-wiki-keeper. The main agent stays focused on the user's task without accumulating wiki read context.\n</commentary>\n</example>\n\n<example>\nContext: User asks what the codebase looks like at a high level.\nuser: \"give me a high-level overview of the codebase architecture\"\nassistant: \"Let me spawn the codedna-wiki-keeper to read and summarize the semantic wiki.\"\n<commentary>\nReading the wiki is also delegated. The keeper reads .codedna and codedna-wiki.md and returns a compact summary.\n</commentary>\n</example>"
+model: haiku
+color: green
+---
+
+You are the **CodeDNA Wiki Keeper** — a focused, low-token specialist that reads and maintains `codedna-wiki.md` as the semantic companion to `.codedna` (Level 0).
+
+You are NOT a general coding assistant. You do exactly one thing: keep the semantic wiki accurate, compact, and useful for agents that come after you.
+
+---
+
+## Your Scope
+
+You touch exactly **one file per task**:
+
+- `codedna-wiki.md` — read it, update it, or summarize it
+
+You may **read** (never write) these files to gather context:
+
+- `.codedna` — Level 0 structural truth (always read this first)
+- `.planning/codebase/*.md` — intermediate codebase map (read when available)
+- `README.md`, `SPEC.md`, `QUICKSTART.md`, `AGENTS.md` — when directly relevant
+- Module docstrings (first 10–15 lines only) of files mentioned in `.codedna`
+
+You do **not** modify source files, annotations, or any file other than `codedna-wiki.md`.
+
+---
+
+## Read workflow (when asked to summarize or explain the codebase)
+
+1. Read `.codedna` — extract project identity, packages, last 2–3 session entries
+2. Read `codedna-wiki.md` — this is your primary answer source
+3. If the wiki is missing or stale, run the refresh workflow first
+4. Return a compact, structured summary (≤400 words unless asked for more)
+
+---
+
+## Refresh workflow (when asked to update the wiki)
+
+1. Read `.codedna`
+2. Read `.planning/codebase/*.md` if the directory exists — skim for structural changes
+3. Read only the module docstrings of files that changed since the last wiki update (check `agent:` dates)
+4. Update `codedna-wiki.md`:
+   - Keep the existing structure; patch only the sections that are stale
+   - Do not rewrite sections that are still accurate
+   - Update `Last refreshed:` date at the top
+   - Add or update the hotspot and drift sections if new issues were found
+5. Report back: what changed, what sections were updated, what you left untouched
+
+---
+
+## Wiki structure to preserve
+
+The wiki must always contain these sections (add if missing):
+
+- **Identity** — what this project is and does
+- **How this wiki relates to L0** — `.codedna` is authoritative; wiki is semantic
+- **Semantic topology** — subsystems, boundaries, key files
+- **Operational workflows** — setup, annotation, maintenance, release
+- **Testing and validation model** — what is covered, what is not
+- **Hotspots and likely drift** — monolithic files, fragile integrations, research noise
+- **Refresh protocol** — when and how to update this file
+
+---
+
+## Output rules
+
+- Keep `codedna-wiki.md` compact (under 250 lines)
+- Semantic synthesis over file inventories — explain WHY, not just WHAT
+- If you find drift between `.codedna` and the wiki, note it explicitly in the Hotspots section
+- If `.codedna` and the wiki disagree on structure, trust `.codedna` and update the wiki
+- End your response to the caller with a one-paragraph summary of what changed
+
+---
+
+## Token discipline
+
+You run as a lightweight model. Apply these constraints:
+
+- Read module docstrings only (first 10–15 lines) unless a full read is strictly necessary
+- Prefer targeted reads (offset + limit) over full file reads
+- Do not load the entire codebase — load what `.codedna` tells you is relevant
+- If `.planning/codebase/` docs exist, prefer reading them over re-reading source files

--- a/.codedna
+++ b/.codedna
@@ -15,6 +15,14 @@ packages:
     purpose: "Utilities for processing agent traces, validating manifests, and extracting city data from CodeDNA sources"
     key_files: [agent_history.py, traces_to_training.py, validate_manifests.py, extract_city_data.py]
 
+  .planning/:
+    purpose: "Planning artifacts for this fork: PRD, codebase maps, and semantic wiki support documents"
+    key_files: [STACK.md, ARCHITECTURE.md, CONCERNS.md, TESTING.md, codedna-wiki-fork-prd.md]
+
+  .agents/:
+    purpose: "Repo-local Codex skills and workflows that extend CodeDNA with project-specific agent behavior"
+    key_files: [SKILL.md]
+
 cross_cutting_patterns: {}
 
 agent_sessions:
@@ -592,3 +600,83 @@ agent_sessions:
       Added module_rules_raw() using raw source snippet. Also: skip *_test.go, cap exports
       at 20, fix provider always "unknown", normalize multi-line rules with comment prefix.
       Tested on gin (59 files, 56 LLM calls) and sinatra (7 files, 6 LLM calls).
+
+  - agent: gpt-5.4
+    provider: openai
+    date: 2026-04-17
+    session_id: s_20260417_001
+    task: "add codex wiki fork baseline and init scaffold"
+    changed:
+      - .planning/prd/codedna-wiki-fork-prd.md
+      - .planning/codebase/STACK.md
+      - .planning/codebase/INTEGRATIONS.md
+      - .planning/codebase/ARCHITECTURE.md
+      - .planning/codebase/STRUCTURE.md
+      - .planning/codebase/CONVENTIONS.md
+      - .planning/codebase/TESTING.md
+      - .planning/codebase/CONCERNS.md
+      - .agents/skills/create-wiki/SKILL.md
+      - codedna-wiki.md
+      - codedna_tool/wiki.py
+      - codedna_tool/cli.py
+      - tests/test_cli.py
+      - .codedna
+    visited:
+      - AGENTS.md
+      - .codedna
+      - README.md
+      - pyproject.toml
+      - codedna_tool/cli.py
+      - codedna_tool/__init__.py
+      - codedna_tool/languages/base.py
+      - tools/validate_manifests.py
+      - benchmark_agent/benchmark_server.py
+      - benchmark_agent/swebench/run_agent_multi.py
+      - examples/python-api/api/routes.py
+      - experiments/run_experiment.py
+      - tests/test_cli.py
+      - tests/conftest.py
+      - integrations/AGENTS.md
+      - codedna-plugin/README.md
+    message: >
+      Created a fork-specific PRD and the first `.planning/codebase/` map, then added a
+      repo-local `create-wiki` skill plus `codedna-wiki.md` as the semantic companion to
+      `.codedna` Level 0. Implemented non-destructive wiki scaffolding in `codedna init`
+      via a dedicated helper module so repeated init runs stay idempotent. Verified with
+      `pytest tests/test_cli.py -q` (16 passed) and `pytest tests/test_refresh.py tests/test_validator.py -q`
+      (36 passed). New repo rule captured in `codedna_tool/cli.py`: init must scaffold wiki
+      assets without overwriting existing files.
+
+  - agent: claude-opus-4-7
+    provider: anthropic
+    date: 2026-04-19
+    session_id: s_20260419_001
+    task: "wiki standalone subcommand + dedicated wiki-keeper sub-agent (haiku)"
+    changed:
+      - codedna_tool/cli.py
+      - codedna_tool/wiki.py
+      - tests/test_cli.py
+      - .agents/skills/create-wiki/SKILL.md
+      - .claude/agents/codedna-wiki-keeper.md
+      - .codedna
+    visited:
+      - .codedna
+      - .planning/prd/codedna-wiki-fork-prd.md
+      - .planning/codebase/STACK.md
+      - .planning/codebase/CONCERNS.md
+      - .agents/skills/create-wiki/SKILL.md
+      - codedna-wiki.md
+      - codedna_tool/wiki.py
+      - codedna_tool/cli.py
+      - tests/test_cli.py
+      - integrations/AGENTS.md
+      - AGENTS.md
+      - .claude/agents/codedna-protocol-enforcer.md
+    message: >
+      Added explicit `codedna wiki [PATH]` subcommand — wiki maintenance is now
+      first-class and independent of init/GSD/any plugin. Added dedicated Claude Code
+      sub-agent `.claude/agents/codedna-wiki-keeper.md` (model: haiku) that isolates
+      wiki reads/writes from the main agent context. `ensure_wiki_scaffold()` now
+      creates 3 assets: skill, wiki, and claude agent. SKILL.md updated to instruct
+      sub-agent spawn in Claude Code context; direct workflow retained for Codex/OpenCode.
+      21 tests pass (cli) + 36 (refresh/validator). Validators clean.

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,10 @@ experiments/runs/run_20260329_163535
 .claude/agent-memory/
 .claude/scheduled_tasks.lock
 .claude/settings.json
+.claude/settings.local.json
+
+# Planning — internal docs not part of protocol changes
+.planning/
 
 # Drafts — not for repo
 note_dev_2

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,198 @@
+# CodeDNA v0.8 — Protocol for Codex
+
+This project uses the **CodeDNA** in-source communication protocol. Follow these rules on every file operation.
+
+---
+
+## Reading files
+
+1. Read the **module docstring** at the top of every Python file before reading any code.
+2. Parse `exports:` — these are symbols you **must never rename or remove** without explicit instruction.
+3. Parse `used_by:` — these are callers that will be affected by your changes.
+4. Parse `rules:` — hard constraints for every edit in this file; read **before writing any logic**.
+5. Parse `agent:` — session history written by previous agents; read to understand *why* the current state exists.
+6. For any function with a `Rules:` docstring, read and respect those before writing logic.
+
+## Writing new files
+
+Every new Python source file **must begin** with a CodeDNA module docstring:
+
+```python
+"""filename.py — <what it does, ≤15 words>.
+
+exports: public_function(arg) -> return_type
+used_by: consumer_file.py → consumer_function
+rules:   <hard constraint agents must never violate>
+agent:   <your-model-id> | <provider> | <YYYY-MM-DD> | <session_id> | <what you implemented and what you noticed>
+         message: "<open hypothesis or observation for the next agent>"
+"""
+```
+
+Field guide:
+
+| Field | Required | Rule |
+|---|---|---|
+| First line | ✅ | `filename.py — <purpose ≤15 words>` |
+| `exports:` | ✅ | Public API with return type |
+| `used_by:` | ✅ | Who calls this file's exports |
+| `rules:` | ✅ | Architectural truth — specific, actionable constraints (see examples below) |
+| `agent:` | ✅ | Session narrative — rolling window of last 5 entries; drop the oldest when adding a 6th |
+| `message:` | ⬜ | Inter-agent channel — open hypotheses, unverified observations (v0.8) |
+
+## Writing good `rules:`
+
+`rules:` must be **specific and actionable** — an agent reading it should know exactly what to do or not do. Never write vague rules.
+
+```python
+# ✅ Good rules: — specific, actionable, explains WHY
+rules:   get_invoices() returns ALL tenants — caller MUST filter is_suspended() before aggregating
+rules:   amount is in cents not euros — divide by 100 before display
+rules:   this endpoint requires admin role — auth middleware is in routes.py, not here
+rules:   soft-delete via deleted_at — NEVER use DELETE, always SET deleted_at = NOW()
+rules:   SQLite has no ALTER COLUMN — schema changes must recreate the table
+
+# ❌ Bad rules: — vague, not actionable
+rules:   handle errors gracefully
+rules:   follow best practices
+rules:   be careful with this code
+rules:   none  ← when there ARE constraints but nobody wrote them
+```
+
+**When to update rules:** every time you discover a constraint, fix a bug, or notice a non-obvious behavior — add it to `rules:` immediately. This is how you communicate with the next agent.
+
+**`rules: none` is acceptable** only when a file truly has no domain constraints (e.g., a simple utility with no side effects). If you see `rules: none` on a file with business logic, add the missing constraints.
+
+## Writing critical functions
+
+Every public function **must** have a `Rules:` docstring:
+
+```python
+def my_function(arg: type) -> return_type:
+    """Short description.
+
+    Rules:   What the agent MUST or MUST NOT do here.
+    message: model-id | YYYY-MM-DD | observation for next agent
+    """
+```
+
+## Inline annotations on complex logic
+
+When writing or editing code blocks with non-obvious logic (complex conditions, algorithms, loops with business rules, edge cases), add a `# Rules:` or `# message:` comment **above** the block:
+
+```python
+# Rules: skip cancelled orders — status=4 means cancelled in legacy DB
+active = [o for o in orders if o.status != 4]
+
+for order in active:
+    # message: exchange rate conversion uses daily rate, not real-time
+    amount = order.amount * get_exchange_rate(order.currency)
+
+    if amount > config.threshold:
+        # Rules: threshold check MUST happen before tax — tax is on gross amount
+        apply_tax(order)
+```
+
+**When to add inline annotations:**
+- Conditional logic that encodes a business rule (`if status != 4`)
+- Loops with non-obvious filtering or transformation
+- Algorithm steps where the order matters
+- Edge cases or workarounds with context that would be lost
+
+**When NOT to add them:**
+- Simple getters/setters
+- Obvious control flow (`if not user: return None`)
+- Standard library usage
+
+## Editing files
+
+1. **First step**: re-read `rules:`, the `agent:` history, and the `Rules:` of the function you are editing.
+2. Apply all file-level constraints before writing.
+3. After editing, check `used_by:` targets (especially `[cascade]`-tagged ones).
+4. Never remove `exports:` symbols — they are contracts used by other files.
+5. If you discover a constraint or fix a bug, **update `rules:` for the next agent** (architectural channel).
+6. **Append a new `agent:` line** to the module docstring after editing: `model-id | provider | YYYY-MM-DD | session_id | what you did and what you noticed`. Keep only the last 5 entries — drop the oldest if adding a 6th. Full history is in git and `.codedna`.
+
+## Session end protocol
+
+At the end of every session that modifies files:
+
+1. Append an `agent_sessions:` entry to `.codedna`:
+
+```yaml
+agent_sessions:
+  - agent: <your-model-id>
+    provider: <anthropic|google|openai|...>
+    date: <YYYY-MM-DD>
+    session_id: <s_YYYYMMDD_NNN>
+    task: "<brief task description ≤15 words>"
+    changed: [list, of, modified, files]
+    visited: [all, files, read, during, session]
+    message: >
+      What you did, what you discovered, what the next agent should know.
+      Constraints found → already added to rules: in the relevant files.
+```
+
+2. If you discovered new packages or dependencies, update `packages:` in `.codedna`.
+
+3. **Commit with AI git trailers** — every commit produced by an AI session must include:
+
+```
+<imperative summary of changes>
+
+AI-Agent:    <model-id>
+AI-Provider: <provider>
+AI-Session:  <session_id>
+AI-Visited:  <comma-separated list of files read>
+AI-Message:  <one-line summary of what was found or left open>
+```
+
+Git is the authoritative audit log. The `.codedna` entry and file-level `agent:` fields are lightweight caches for agent navigation — git trailers are the source of truth for history and verification.
+
+## `message:` — Agent Chat Layer *(v0.8 experimental)*
+
+The `message:` sub-field adds a conversational layer to `agent:` entries. Use it for observations not yet certain enough to become `rules:`, open questions, and notes for the next agent.
+
+**In module docstrings (Level 1):**
+```python
+agent:   Codex-sonnet-4-6 | anthropic | 2026-03-20 | s_20260320_001 | Implemented X.
+         message: "noticed Y behaviour — not yet sure if this should be a rule"
+```
+
+**In function docstrings (Level 2) — for sliding window safety:**
+```python
+def my_function():
+    """Short description.
+
+    Rules:   hard constraint here
+    message: Codex-sonnet-4-6 | 2026-03-20 | open observation for next agent
+    """
+```
+
+**Lifecycle:** a `message:` is either promoted to `rules:` (reply `"@prev: promoted to rules:"`) or dismissed (`"@prev: verified, not applicable because..."`). Always append-only — never delete.
+
+## Planning across multiple files
+
+Use manifest-only read mode: read only the module docstring (first 8–12 lines) of each file to build an architectural map before deciding which files to open fully.
+
+At session start, also read the last 3–5 `agent_sessions:` entries in `.codedna` to understand recent project history.
+
+Filter by priority:
+- File has `used_by:` mentioning the file you're editing → always include
+- File has `rules:` field mentioning the task domain → always include
+- Otherwise → skip unless referenced
+
+## Semantic naming convention
+
+For data-carrying variables, use: `<type>_<shape>_<domain>_<origin>`
+
+```python
+# ✅ CodeDNA style
+list_dict_users_from_db = get_users()
+str_html_dashboard_rendered = render(query_fn)
+int_cents_price_from_request = request.json["price"]
+
+# ❌ avoid
+data = get_users()
+result = render(query_fn)
+price = request.json["price"]
+```

--- a/codedna-wiki.md
+++ b/codedna-wiki.md
@@ -1,0 +1,161 @@
+# CodeDNA Wiki
+
+Last refreshed: 2026-04-17
+Primary structural source: [.codedna](/Users/elettrofranky/python-projects/codedna/.codedna)
+Semantic support artifacts: [.planning/codebase/](/Users/elettrofranky/python-projects/codedna/.planning/codebase)
+
+## Identity
+
+`codedna` is both:
+
+- a shipping CLI/tooling package for in-source agent annotations
+- a research repo that benchmarks and documents the protocol on real tasks
+
+The product core is small and centered on `codedna_tool/`; the repo surface is much larger because it also contains experiments, benchmark harnesses, papers, and integration templates.
+
+## How this wiki relates to L0
+
+Use `.codedna` as Level 0 truth for:
+
+- project identity
+- package boundaries
+- recent agent sessions
+
+Use this wiki for:
+
+- semantic topology
+- mental model of the product and research layers
+- hotspots, drift risks, and navigation advice
+
+If this file and `.codedna` disagree on structure, trust `.codedna` and refresh this file.
+
+## Semantic topology
+
+### 1. Product engine
+
+The operational heart of the repo is [codedna_tool/cli.py](/Users/elettrofranky/python-projects/codedna/codedna_tool/cli.py). It owns:
+
+- command dispatch
+- Python scanning and dependency graph building
+- docstring injection
+- non-Python annotation orchestration
+- install-time integration setup
+- manifest generation
+
+This is the highest-leverage file for product changes and the riskiest place for regressions.
+
+### 2. Language adapter layer
+
+`codedna_tool/languages/` is the extension seam. The repo supports a hybrid parsing model:
+
+- tree-sitter for strong structural extraction where bindings exist
+- regex fallback adapters for resilience and portability
+
+The stable contract is [codedna_tool/languages/base.py](/Users/elettrofranky/python-projects/codedna/codedna_tool/languages/base.py).
+
+### 3. Protocol and documentation layer
+
+The repo’s actual “product spec” is spread across:
+
+- [README.md](/Users/elettrofranky/python-projects/codedna/README.md)
+- [QUICKSTART.md](/Users/elettrofranky/python-projects/codedna/QUICKSTART.md)
+- [SPEC.md](/Users/elettrofranky/python-projects/codedna/SPEC.md)
+- [AGENTS.md](/Users/elettrofranky/python-projects/codedna/AGENTS.md)
+
+This layer matters operationally because the tool exists to instantiate the protocol described there.
+
+### 4. Validation layer
+
+The repo protects itself mainly through:
+
+- CLI subprocess tests in [tests/test_cli.py](/Users/elettrofranky/python-projects/codedna/tests/test_cli.py)
+- refresh and validator tests in `tests/test_refresh.py` and `tests/test_validator.py`
+- adapter regression suites in `tests/test_language_adapters.py` and `tests/test_integration_langs.py`
+- standalone validation logic in [tools/validate_manifests.py](/Users/elettrofranky/python-projects/codedna/tools/validate_manifests.py)
+
+### 5. Research and proof layer
+
+The benchmark and experiment surfaces exist to demonstrate or stress the protocol:
+
+- `benchmark_agent/` for benchmark harnesses and live benchmark UI/server
+- `experiments/` for multi-agent product experiments
+- `paper/`, `thesis/`, `docs/` for publication and visualization artifacts
+
+These directories are important context, but they should not dominate everyday product edits.
+
+## Operational workflows
+
+### Install and setup
+
+`codedna install` prepares a project with:
+
+- prompt templates for agent runtimes
+- optional hook setup
+- a starter `.codedna`
+
+This path depends on remote template fetches from GitHub raw URLs.
+
+### Annotation flow
+
+`codedna init` is the first-write path:
+
+- scan files
+- build reverse dependency graph
+- write L1 / L2 annotations
+
+In this fork, it also scaffolds the semantic wiki layer:
+
+- `.agents/skills/create-wiki/SKILL.md`
+- `codedna-wiki.md`
+
+### Maintenance flow
+
+- `codedna update` annotates only missing files
+- `codedna refresh` repairs structural drift without touching semantic fields
+- `codedna check` measures coverage
+- `codedna manifest` regenerates `.codedna` package structure while preserving session history
+
+## Testing and validation model
+
+The repo optimizes for:
+
+- idempotent annotation
+- structural correctness of headers
+- adapter coverage across many languages
+
+It is less opinionated, today, about validating higher-level semantic synthesis. That is one of the gaps this wiki layer is meant to reduce.
+
+## Hotspots and likely drift
+
+### Monolithic CLI
+
+`codedna_tool/cli.py` changes easily accumulate unrelated responsibilities. Any new feature should either stay very small or carve out a helper boundary.
+
+### Remote integration templates
+
+Install-time prompt files and hooks are fetched remotely. Template drift can desynchronize packaged behavior from repository expectations.
+
+### Research noise
+
+`experiments/` is much larger than the production package. Agents can burn context there if they do not anchor on `.codedna`, `.planning/codebase/`, and `codedna_tool/` first.
+
+### Semantic gap
+
+Before this fork, the repo had structural truth and local file truth but no durable semantic synthesis artifact. This file is intended to close that gap.
+
+## Refresh protocol
+
+Refresh this wiki when:
+
+- `.planning/codebase/` is regenerated
+- `codedna_tool/cli.py` changes meaningfully
+- install/integration strategy changes
+- language adapter architecture changes
+- test strategy changes
+
+When refreshing:
+
+1. re-read `.codedna`
+2. re-read `.planning/codebase/*.md`
+3. inspect only the changed files needed to update the semantic model
+4. keep this file compact and explanatory rather than exhaustive

--- a/codedna_tool/cli.py
+++ b/codedna_tool/cli.py
@@ -6,14 +6,17 @@ used_by: tests/test_cli.py → FileInfo, build_module_docstring
 rules:   L2 (function Rules:) applies Python AST only; language adapters are L1-only.
 LLM calls are capped at 2 per Python file; --no-llm skips all LLM calls.
 _resolve_dep must NOT filter by top_pkg — filesystem existence is the guard.
+`init` must scaffold `codedna-wiki.md` and `.agents/skills/create-wiki/SKILL.md`
+idempotently at repo root without overwriting existing wiki assets.
 scan_file handles 3 import patterns: (1) from .mod import X, (2) from . import X
 (submodule-first then __init__.py symbol), (3) from pkg import X (tries pkg/X.py
 before falling back to pkg/__init__.py). All 3 were previously under-resolved.
-agent:   claude-sonnet-4-6 | anthropic | 2026-04-16 | s_20260416_003 | add DeepSeek to _detect_provider and env_map so --api-key works with deepseek/ model prefix
-claude-sonnet-4-6 | anthropic | 2026-04-16 | s_20260416_004 | fix L2 batch overflow: _L2_BATCH_SIZE=12, dynamic max_tokens, _parse_json_response with truncation recovery
+agent:   claude-sonnet-4-6 | anthropic | 2026-04-16 | s_20260416_004 | fix L2 batch overflow: _L2_BATCH_SIZE=12, dynamic max_tokens, _parse_json_response with truncation recovery
 claude-sonnet-4-6 | anthropic | 2026-04-16 | s_20260416_004 | skip *_test.go; cap exports@20; fix non-Python path (raw join→_fmt_exports, module_rules→module_rules_raw, provider detection)
 claude-sonnet-4-6 | anthropic | 2026-04-16 | s_20260416_005 | run_lang_files returns (annotated, llm_calls) tuple; run() aggregates lang llm_calls into summary counter
 claude-sonnet-4-6 | anthropic | 2026-04-16 | s_20260416_bench | fix 3 used_by bugs in scan_file; fix LLM gating: run() checked HAS_ANTHROPIC instead of HAS_LITELLM|HAS_ANTHROPIC — litellm (DeepSeek/GPT) was silently falling back to --no-llm
+gpt-5.4 | openai | 2026-04-17 | s_20260417_001 | scaffold repo-local create-wiki skill and codedna-wiki.md after init via dedicated helper module
+claude-opus-4-7 | anthropic | 2026-04-19 | s_20260419_001 | add explicit `codedna wiki` subcommand so semantic wiki is independent of init; idempotent scaffold with --dry-run
 AST for structure (exports, used_by, candidates). Python only.
 LLM only for semantic content (rules:, function Rules:).
 Language adapters for non-Python files (TypeScript, Go, …) via languages/ package.
@@ -22,6 +25,7 @@ install        Setup CodeDNA in a project (pre-commit hook + AI tool prompt + .c
 init   PATH    First-time annotation of every source file under PATH
 update PATH    Annotate only files missing CodeDNA headers (incremental)
 check  PATH    Report annotation coverage without modifying files
+wiki   [PATH]  Scaffold codedna-wiki.md and repo-local create-wiki skill (idempotent)
 LLM calls: max 2 per Python file (1 module skeleton rules + 1 function batch).
 0 calls if file already annotated (skipped by init/update).
 Non-Python files: 1 LLM call per file for rules: (or none with --no-llm).
@@ -44,6 +48,7 @@ from pathlib import Path
 from typing import Optional
 
 from .languages import SUPPORTED_EXTENSIONS, get_adapter
+from .wiki import ensure_wiki_scaffold
 
 try:
     import litellm as _litellm
@@ -2330,6 +2335,24 @@ def main():
     manifest_p.add_argument("-v", "--verbose", action="store_true",
                             help="Show per-package details")
 
+    # ── wiki ─────────────────────────────────────────────────────────────────
+    wiki_p = subs.add_parser(
+        "wiki",
+        help="Scaffold the semantic wiki companion to .codedna (codedna-wiki.md + create-wiki skill)",
+        description=(
+            "Create the CodeDNA semantic wiki assets at the project root:\n"
+            "  - codedna-wiki.md                         (semantic companion to .codedna)\n"
+            "  - .agents/skills/create-wiki/SKILL.md     (repo-local skill)\n\n"
+            "Idempotent: existing files are never overwritten.\n"
+            "Use --dry-run to preview what would be created."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    wiki_p.add_argument("path", type=Path, nargs="?", default=Path("."),
+                        help="Project root (default: current directory)")
+    wiki_p.add_argument("--dry-run", action="store_true",
+                        help="Report missing files without writing them")
+
     args = p.parse_args()
 
     # ── dispatch ──────────────────────────────────────────────────────────────
@@ -2420,6 +2443,22 @@ def main():
             exclude=list(args.exclude),
         )
 
+    if args.command == "wiki":
+        path_project_root = args.path.resolve()
+        if not path_project_root.exists():
+            print(f"Error: {path_project_root} does not exist", file=sys.stderr)
+            return 1
+        obj_wiki_result = ensure_wiki_scaffold(path_project_root, dry_run=args.dry_run)
+        if obj_wiki_result.created:
+            verb = "Would create" if args.dry_run else "Created"
+            for str_path in obj_wiki_result.created:
+                print(f"{verb:<11} {str_path}")
+        for str_path in obj_wiki_result.existing:
+            print(f"Reused      {str_path}")
+        if not obj_wiki_result.created and not obj_wiki_result.existing:
+            print("No wiki assets to scaffold.")
+        return 0
+
     if args.command == "refresh":
         target = args.path.resolve()
         if not target.exists():
@@ -2469,6 +2508,19 @@ def main():
         repo_root=repo_root,
         extensions=exts,
     )
+
+    if args.command == "init":
+        path_project_root = repo_root or (target if target.is_dir() else target.parent)
+        obj_wiki_result = ensure_wiki_scaffold(path_project_root, dry_run=args.dry_run)
+        if obj_wiki_result.created or obj_wiki_result.existing:
+            print()
+            print("Wiki scaffold")
+            if obj_wiki_result.created:
+                verb = "Would create" if args.dry_run else "Created"
+                for str_path in obj_wiki_result.created:
+                    print(f"  {verb:<11} {str_path}")
+            for str_path in obj_wiki_result.existing:
+                print(f"  Reused      {str_path}")
     return 0
 
 

--- a/codedna_tool/wiki.py
+++ b/codedna_tool/wiki.py
@@ -1,0 +1,386 @@
+"""wiki.py — Scaffold semantic wiki assets for CodeDNA projects.
+
+exports: class WikiScaffoldResult | render_create_wiki_skill(project_name) -> str | render_wiki_keeper_agent(project_name) -> str | render_codedna_wiki(project_root, project_name) -> str | ensure_wiki_scaffold(project_root, dry_run) -> WikiScaffoldResult
+used_by: codedna_tool/cli.py → ensure_wiki_scaffold
+rules:   Never overwrite existing wiki assets; scaffold only missing files.
+         `codedna-wiki.md` must present `.codedna` as Level 0 structural truth.
+         Repo-local Codex skill must live at `.agents/skills/create-wiki/SKILL.md`.
+         Claude Code agent must live at `.claude/agents/codedna-wiki-keeper.md` (model: haiku).
+agent:   gpt-5.4 | openai | 2026-04-17 | s_20260417_001 | scaffolded repo-local create-wiki skill and codedna-wiki baseline for init
+         message: "Template is intentionally compact; future pass can enrich it from .planning/codebase automatically when present."
+         claude-opus-4-7 | anthropic | 2026-04-19 | s_20260419_001 | add wiki-keeper Claude Code sub-agent scaffold; skill updated to instruct spawn in CC context
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+import re
+
+
+_SKILL_PATH = Path(".agents/skills/create-wiki/SKILL.md")
+_WIKI_PATH = Path("codedna-wiki.md")
+_AGENT_PATH = Path(".claude/agents/codedna-wiki-keeper.md")
+_SKIP_DIRS = {".git", ".venv", "venv", "__pycache__", "node_modules", "dist", "build"}
+
+
+@dataclass
+class WikiScaffoldResult:
+    """Track which wiki assets were created or already existed.
+
+    Rules:   `created` and `existing` store repo-relative POSIX paths for stable CLI output.
+    """
+
+    created: list[str] = field(default_factory=list)
+    existing: list[str] = field(default_factory=list)
+
+
+def _read_project_name(project_root: Path) -> str:
+    """Return project name from `.codedna` when available, else directory name."""
+    path_codedna = project_root / ".codedna"
+    if path_codedna.exists():
+        str_content = path_codedna.read_text(encoding="utf-8", errors="replace")
+        obj_match = re.search(r"^project:\s*\"?(.+?)\"?\s*$", str_content, re.MULTILINE)
+        if obj_match:
+            return obj_match.group(1).strip()
+    return project_root.name
+
+
+def _list_top_level_dirs(project_root: Path) -> list[str]:
+    """List stable top-level directories for the starter wiki map."""
+    list_str_dirs: list[str] = []
+    for path_child in sorted(project_root.iterdir()):
+        if not path_child.is_dir():
+            continue
+        if path_child.name in _SKIP_DIRS:
+            continue
+        list_str_dirs.append(path_child.name)
+    return list_str_dirs[:8]
+
+
+def render_wiki_keeper_agent(project_name: str) -> str:
+    """Render the Claude Code sub-agent definition for isolated wiki maintenance.
+
+    Rules:   model must be haiku for token efficiency.
+             Agent scope is read-only except for codedna-wiki.md.
+             Description must include spawn trigger conditions for auto-dispatch.
+    """
+    return f"""---
+name: codedna-wiki-keeper
+description: "Dedicated wiki maintenance agent for `{project_name}`. Spawn this agent when any of the following occur: (1) user asks to read, summarize, refresh, or update codedna-wiki.md; (2) codedna init or codedna wiki just ran; (3) a major refactor or architecture change landed; (4) .planning/codebase/ was regenerated. This agent reads .codedna and relevant files then updates codedna-wiki.md in isolation — keeping wiki maintenance out of the main agent context window."
+model: haiku
+color: green
+---
+
+You are the **CodeDNA Wiki Keeper** for `{project_name}` — a focused, low-token specialist that reads and maintains `codedna-wiki.md` as the semantic companion to `.codedna` (Level 0).
+
+You are NOT a general coding assistant. You do exactly one thing: keep the semantic wiki accurate, compact, and useful for agents that come after you.
+
+---
+
+## Your Scope
+
+You touch exactly **one file per task**:
+
+- `codedna-wiki.md` — read it, update it, or summarize it
+
+You may **read** (never write) these files to gather context:
+
+- `.codedna` — Level 0 structural truth (always read this first)
+- `.planning/codebase/*.md` — intermediate codebase map (read when available)
+- `README.md`, `SPEC.md`, `QUICKSTART.md`, `AGENTS.md` — when directly relevant
+- Module docstrings (first 10–15 lines only) of files mentioned in `.codedna`
+
+You do **not** modify source files, annotations, or any file other than `codedna-wiki.md`.
+
+---
+
+## Read workflow (when asked to summarize or explain the codebase)
+
+1. Read `.codedna` — extract project identity, packages, last 2–3 session entries
+2. Read `codedna-wiki.md` — this is your primary answer source
+3. If the wiki is missing or stale, run the refresh workflow first
+4. Return a compact, structured summary (≤400 words unless asked for more)
+
+---
+
+## Refresh workflow (when asked to update the wiki)
+
+1. Read `.codedna`
+2. Read `.planning/codebase/*.md` if the directory exists — skim for structural changes
+3. Read only the module docstrings of files that changed since the last wiki update
+4. Update `codedna-wiki.md`:
+   - Keep the existing structure; patch only the sections that are stale
+   - Do not rewrite sections that are still accurate
+   - Update `Last refreshed:` date at the top
+   - Add or update the hotspot and drift sections if new issues were found
+5. Report back: what changed, what sections were updated, what you left untouched
+
+---
+
+## Wiki structure to preserve
+
+The wiki must always contain these sections (add if missing):
+
+- **Identity** — what this project is and does
+- **How this wiki relates to L0** — `.codedna` is authoritative; wiki is semantic
+- **Semantic topology** — subsystems, boundaries, key files
+- **Operational workflows** — setup, annotation, maintenance, release
+- **Testing and validation model** — what is covered, what is not
+- **Hotspots and likely drift** — monolithic files, fragile integrations, research noise
+- **Refresh protocol** — when and how to update this file
+
+---
+
+## Output rules
+
+- Keep `codedna-wiki.md` compact (under 250 lines)
+- Semantic synthesis over file inventories — explain WHY, not just WHAT
+- If you find drift between `.codedna` and the wiki, note it explicitly in Hotspots
+- If `.codedna` and the wiki disagree on structure, trust `.codedna` and update the wiki
+- End your response to the caller with a one-paragraph summary of what changed
+
+---
+
+## Token discipline
+
+You run as a lightweight model. Apply these constraints:
+
+- Read module docstrings only (first 10–15 lines) unless a full read is strictly necessary
+- Prefer targeted reads (offset + limit) over full file reads
+- Do not load the entire codebase — load what `.codedna` tells you is relevant
+- If `.planning/codebase/` docs exist, prefer reading them over re-reading source files
+"""
+
+
+def render_create_wiki_skill(project_name: str) -> str:
+    """Render repo-local skill instructions for semantic wiki upkeep across runtimes.
+
+    Rules:   Output must stay markdown-only and reference `.codedna` as L0.
+             Claude Code section must instruct sub-agent spawn (codedna-wiki-keeper).
+             Direct workflow section must cover Codex/OpenCode fallback.
+    """
+    return f"""---
+name: create-wiki
+description: Maintain `codedna-wiki.md` as the semantic companion to `.codedna` (L0) for `{project_name}`.
+model: haiku
+preferred-model: haiku
+model-hint: "Use the smallest available model. This task is read-heavy markdown synthesis — Haiku or equivalent (GPT-4o-mini, Gemini Flash, Qwen-turbo). Never use Opus/o3/Pro for wiki-only tasks."
+---
+
+# Create Wiki
+
+Use this skill when the user asks to create, refresh, repair, or extend the project wiki, or when the codebase changed enough that the semantic map is stale.
+
+## Model preference
+
+This skill runs on a **lightweight model**. Match to your runtime:
+
+| Runtime | Preferred model |
+|---------|----------------|
+| Claude Code | `haiku` (enforced via `.claude/agents/codedna-wiki-keeper.md`) |
+| Codex | `o4-mini` or smallest available |
+| OpenCode | smallest configured model |
+| Gemini | `gemini-flash` |
+| Other | any fast/cheap tier |
+
+Wiki maintenance is read-heavy markdown synthesis — no code generation, no reasoning-intensive tasks. Saving tokens here is free performance.
+
+## Core idea
+
+This skill follows the `llm-wiki` pattern from Karpathy's note:
+
+- persistent compiled knowledge beats rebuilding the same understanding every session
+- the wiki is not a dump of files; it is the semantic model of the codebase
+
+For CodeDNA projects:
+
+- `.codedna` is Level 0 structural truth
+- source file docstrings are local truth
+- `codedna-wiki.md` is the semantic synthesis layer
+
+---
+
+## Sub-agent dispatch (Claude Code)
+
+**In Claude Code: do not perform wiki work inline.** Spawn the dedicated wiki-keeper sub-agent to isolate all wiki reads from your context window:
+
+Use the Agent tool with `subagent_type="codedna-wiki-keeper"` and pass the task as a clear prompt, for example:
+
+- `"Refresh codedna-wiki.md — a major refactor just landed"`
+- `"Read codedna-wiki.md and summarize the architecture for onboarding"`
+- `"Update the hotspots section — we just added a new subsystem"`
+
+The wiki-keeper runs on Haiku, keeps wiki context isolated, and returns a compact summary.
+
+If `.claude/agents/codedna-wiki-keeper.md` is missing, run `codedna wiki` first to scaffold it.
+
+---
+
+## Direct workflow (Codex, OpenCode, other runtimes)
+
+When sub-agent spawning is not available, perform wiki work directly.
+
+### Inputs
+
+Read in this order:
+
+1. `.codedna`
+2. `.planning/codebase/*.md` when available
+3. `README.md`, `SPEC.md`, `QUICKSTART.md`, `AGENTS.md` when relevant
+4. only the module docstrings or focused files needed for the current refresh
+
+### Output
+
+Update exactly one semantic artifact:
+
+- `codedna-wiki.md`
+
+### Rules
+
+- Treat `.codedna` as authoritative for package structure and recent sessions
+- Do not invent structural relationships that contradict `.codedna`
+- Prefer semantic synthesis over raw inventories
+- Preserve architecture, hotspots, contradictions, and refresh guidance
+- If `.planning/codebase/` exists, use it as support context but keep `codedna-wiki.md` shorter and more decisive
+- Call out drift explicitly when the wiki and L0 no longer match
+
+### Recommended structure
+
+- Project identity
+- Relationship to L0 (`.codedna`)
+- Semantic topology
+- Operational workflows
+- Testing and validation model
+- Hotspots and likely drift
+- Refresh protocol
+
+### Refresh workflow
+
+1. Re-read `.codedna`
+2. Re-read `.planning/codebase/*.md` if present
+3. Inspect only the files needed for the affected semantic sections
+4. Update `codedna-wiki.md`
+5. Keep the wiki compact and high-signal
+"""
+
+
+def render_codedna_wiki(project_root: Path, project_name: str) -> str:
+    """Render the starter semantic wiki that complements `.codedna`.
+
+    Rules:   Keep the wiki generic enough for any project root while making L0 explicit.
+    """
+    list_str_dirs = _list_top_level_dirs(project_root)
+    list_str_topology = "\n".join(f"- `{name}/`" for name in list_str_dirs) or "- Add major subsystem directories here"
+
+    return f"""# CodeDNA Wiki
+
+Last refreshed: 2026-04-19
+Primary structural source: `.codedna`
+Repo-local wiki skill: `.agents/skills/create-wiki/SKILL.md`
+Wiki keeper agent: `.claude/agents/codedna-wiki-keeper.md`
+
+## Identity
+
+`{project_name}` uses CodeDNA as its in-source coordination protocol.
+
+This file is the semantic companion to `.codedna`:
+
+- `.codedna` is Level 0 structural truth
+- `codedna-wiki.md` is the semantic map agents use to preserve architectural understanding over time
+
+## Semantic topology
+
+Starter top-level view:
+
+{list_str_topology}
+
+Use this section to explain what each subsystem is for, how the boundaries work, and where agents should start reading.
+
+## How this complements L0
+
+Use `.codedna` for:
+
+- project/package structure
+- key files
+- recent session log
+
+Use this wiki for:
+
+- architecture mental model
+- workflows
+- hotspots and drift
+- contradictions or open questions
+
+If this file disagrees with `.codedna`, refresh this file and trust `.codedna` first.
+
+## Operational workflows
+
+Track the workflows that matter most to the project:
+
+- setup and install
+- main runtime path
+- test path
+- release or validation path
+
+## Hotspots and likely drift
+
+Document:
+
+- monolithic files
+- fragile integrations
+- generated areas to avoid
+- places where structure and intent often diverge
+
+## Refresh protocol
+
+Refresh this file when:
+
+- `.codedna` changes meaningfully
+- `.planning/codebase/` is generated or refreshed
+- major refactors land
+- new subsystems or workflows appear
+
+When refreshing (Claude Code):
+
+1. spawn `codedna-wiki-keeper` sub-agent via Agent tool
+2. pass task prompt describing what changed
+3. keeper returns summary of updates
+
+When refreshing (other runtimes):
+
+1. read `.codedna`
+2. read `.planning/codebase/*.md` if present
+3. inspect only the focused files needed for the semantic update
+4. keep this file shorter and more explanatory than the codebase map
+"""
+
+
+def ensure_wiki_scaffold(project_root: Path, dry_run: bool = False) -> WikiScaffoldResult:
+    """Create repo-local wiki assets if they do not already exist.
+
+    Rules:   `project_root` is the repository root for the target project.
+             Dry-run mode must report missing files without writing them.
+             _AGENT_PATH is Claude Code specific but harmless on other runtimes.
+    """
+    obj_result = WikiScaffoldResult()
+    str_project_name = _read_project_name(project_root)
+    dict_path_content = {
+        _SKILL_PATH: render_create_wiki_skill(str_project_name),
+        _WIKI_PATH: render_codedna_wiki(project_root, str_project_name),
+        _AGENT_PATH: render_wiki_keeper_agent(str_project_name),
+    }
+
+    for path_rel, str_content in dict_path_content.items():
+        path_abs = project_root / path_rel
+        str_rel = path_rel.as_posix()
+        if path_abs.exists():
+            obj_result.existing.append(str_rel)
+            continue
+        obj_result.created.append(str_rel)
+        if dry_run:
+            continue
+        path_abs.parent.mkdir(parents=True, exist_ok=True)
+        path_abs.write_text(str_content, encoding="utf-8")
+
+    return obj_result

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,7 +4,9 @@ exports: PYTHON | run_codedna() | class TestInit | class TestCheck | class TestR
 used_by: none
 rules:   Tests run codedna CLI as subprocess to verify end-to-end behavior.
 Each test uses tmp_path for isolation — never touches real project files.
+`init` coverage must include repo-level side effects such as wiki scaffolding.
 agent:   claude-opus-4-6 | anthropic | 2026-04-15 | s_20260415_002 | initial CLI test suite
+gpt-5.4 | openai | 2026-04-17 | s_20260417_001 | added init coverage for create-wiki skill scaffold, codedna-wiki.md, and dry-run/idempotency behavior
 """
 
 from __future__ import annotations
@@ -20,7 +22,11 @@ PYTHON = sys.executable
 
 
 def run_codedna(*args, cwd=None):
-    """Run codedna CLI and return (returncode, stdout, stderr)."""
+    """Run codedna CLI and return (returncode, stdout, stderr).
+
+    Rules:   Always invoke the module entrypoint (`python -m codedna_tool.cli`) so tests
+             exercise the real CLI dispatch path.
+    """
     result = subprocess.run(
         [PYTHON, "-m", "codedna_tool.cli", *args],
         capture_output=True, text=True, cwd=cwd, timeout=60,
@@ -96,6 +102,80 @@ class TestInit:
 
         ts_content = (mini_project / "app.ts").read_text()
         assert "exports:" in ts_content or "// app.ts" in ts_content
+
+    def test_init_scaffolds_create_wiki_skill_and_wiki(self, mini_project):
+        rc, out, err = run_codedna("init", str(mini_project), "--no-llm")
+
+        assert rc == 0
+        assert (mini_project / ".agents" / "skills" / "create-wiki" / "SKILL.md").exists()
+        assert (mini_project / "codedna-wiki.md").exists()
+
+        wiki_content = (mini_project / "codedna-wiki.md").read_text()
+        assert ".codedna" in wiki_content
+        assert "semantic companion" in wiki_content
+
+    def test_init_wiki_scaffold_is_idempotent(self, mini_project):
+        run_codedna("init", str(mini_project), "--no-llm")
+
+        skill_path = mini_project / ".agents" / "skills" / "create-wiki" / "SKILL.md"
+        wiki_path = mini_project / "codedna-wiki.md"
+        skill_first = skill_path.read_text()
+        wiki_first = wiki_path.read_text()
+
+        run_codedna("init", str(mini_project), "--no-llm")
+
+        assert skill_first == skill_path.read_text()
+        assert wiki_first == wiki_path.read_text()
+
+    def test_init_dry_run_does_not_create_wiki_scaffold(self, mini_project):
+        rc, out, err = run_codedna("init", str(mini_project), "--no-llm", "--dry-run")
+
+        assert rc == 0
+        assert not (mini_project / ".agents" / "skills" / "create-wiki" / "SKILL.md").exists()
+        assert not (mini_project / "codedna-wiki.md").exists()
+
+
+# ── codedna wiki (standalone, no init required) ──────────────────────────────
+
+class TestWiki:
+    def test_wiki_scaffolds_without_init(self, tmp_path):
+        rc, out, err = run_codedna("wiki", str(tmp_path))
+
+        assert rc == 0
+        assert (tmp_path / "codedna-wiki.md").exists()
+        assert (tmp_path / ".agents" / "skills" / "create-wiki" / "SKILL.md").exists()
+        assert (tmp_path / ".claude" / "agents" / "codedna-wiki-keeper.md").exists()
+        assert "Created" in out
+
+    def test_wiki_scaffolds_claude_agent_with_haiku_model(self, tmp_path):
+        run_codedna("wiki", str(tmp_path))
+        agent_content = (tmp_path / ".claude" / "agents" / "codedna-wiki-keeper.md").read_text()
+        assert "model: haiku" in agent_content
+        assert "codedna-wiki-keeper" in agent_content
+
+    def test_wiki_skill_references_subagent_spawn(self, tmp_path):
+        run_codedna("wiki", str(tmp_path))
+        skill_content = (tmp_path / ".agents" / "skills" / "create-wiki" / "SKILL.md").read_text()
+        assert "codedna-wiki-keeper" in skill_content
+        assert "haiku" in skill_content.lower() or "sub-agent" in skill_content.lower()
+
+    def test_wiki_dry_run_writes_nothing(self, tmp_path):
+        rc, out, err = run_codedna("wiki", str(tmp_path), "--dry-run")
+
+        assert rc == 0
+        assert "Would create" in out
+        assert not (tmp_path / "codedna-wiki.md").exists()
+        assert not (tmp_path / ".agents" / "skills" / "create-wiki" / "SKILL.md").exists()
+        assert not (tmp_path / ".claude" / "agents" / "codedna-wiki-keeper.md").exists()
+
+    def test_wiki_idempotent(self, tmp_path):
+        run_codedna("wiki", str(tmp_path))
+        wiki_first = (tmp_path / "codedna-wiki.md").read_text()
+
+        rc, out, err = run_codedna("wiki", str(tmp_path))
+        assert rc == 0
+        assert "Reused" in out
+        assert (tmp_path / "codedna-wiki.md").read_text() == wiki_first
 
 
 # ── codedna check ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Adds `codedna wiki` — explicit CLI subcommand to scaffold the semantic wiki layer, independent of `codedna init` and any external plugin (GSD, OpenCode, etc.)
- Adds `codedna_tool/wiki.py` — scaffold helper that creates 3 assets idempotently: skill, wiki, and Claude Code sub-agent
- Adds `.agents/skills/create-wiki/SKILL.md` — cross-runtime skill with `model: haiku` / `preferred-model: haiku` / `model-hint` fields for token-efficient execution on Claude Code, Codex, OpenCode, and Gemini
- Adds `.claude/agents/codedna-wiki-keeper.md` — Claude Code sub-agent (model: haiku) that isolates all wiki reads/writes from the main agent context window
- Adds `codedna-wiki.md` — semantic companion to `.codedna` (L0), following the Karpathy llm-wiki pattern: persistent compiled knowledge, not a cache rebuilt every session
- Wires wiki scaffold into `codedna init` (idempotent, never overwrites existing files)
- Adds `AGENTS.md` for Codex runtime integration
- Updates `.gitignore`: excludes `.planning/` and `.claude/settings.local.json`

## Design decisions

**Standalone autonomy:** `codedna wiki` has zero dependency on GSD or any other plugin. Works with `.codedna`, pure Python stdlib, and text templates only.

**Context isolation:** In Claude Code, `create-wiki` skill instructs the orchestrator to spawn `codedna-wiki-keeper` via the Agent tool. The keeper runs on Haiku, reads only what `.codedna` says is relevant, and returns a compact summary. Main agent context stays clean.

**Cross-runtime model hints:** The skill frontmatter carries `model: haiku`, `preferred-model: haiku`, and a `model-hint` string with per-runtime equivalents (o4-mini for Codex, gemini-flash for Gemini). Claude Code is the only runtime that enforces the model; others read it as advisory.

**Idempotency:** Every scaffold path checks existence before writing. Re-running `codedna wiki` or `codedna init` reports "Reused" and never overwrites user-authored content.

## Test plan

- [x] `codedna wiki` creates all 3 assets from scratch
- [x] `codedna wiki --dry-run` reports without writing
- [x] `codedna wiki` is idempotent on re-run
- [x] `.claude/agents/codedna-wiki-keeper.md` contains `model: haiku`
- [x] `create-wiki/SKILL.md` references `codedna-wiki-keeper` and haiku
- [x] `codedna init` still scaffolds wiki assets (existing tests pass)
- [x] 21 CLI tests pass, 36 refresh/validator tests pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)