### PR TITLE
fix: PHP mixed-HTML headers (#4), VB.NET adapter (#6), Roo Code install (#7)

### DIFF
--- a/.codedna
+++ b/.codedna
@@ -33,14 +33,6 @@ agent_sessions:
   - agent: "gpt-5"
     provider: "openai"
     date: "2026-08-21"
-    session_id: "s_20260821_commit_push"
-    task: "Prepare verified release changes for push"
-    changed: [".gitignore",".codedna"]
-    visited: [".gitignore",".vscode/settings.json",".codedna"]
-    message: "Ignored local VS Code Live Server settings before committing the accumulated verified CodeDNA changes. The removed legacy logo video and updated site logo are intentional site assets."
-  - agent: "gpt-5"
-    provider: "openai"
-    date: "2026-08-21"
     session_id: "s_20260821_gitbook_docs"
     task: "Redesign documentation like GitBook"
     changed: ["docs/install.html","docs/site.css",".codedna"]
@@ -70,3 +62,11 @@ agent_sessions:
     changed: ["codedna_tool/cli.py","codedna_tool/languages/base.py","tests/test_language_adapters.py","tests/test_refresh.py",".codedna"]
     visited: [".codedna","codedna_tool/cli.py","codedna_tool/audit.py","codedna_tool/wiki.py","codedna_tool/languages/__init__.py","codedna_tool/languages/base.py","codedna_tool/languages/php.py","codedna_tool/languages/_ts_php.py","tests/test_cli.py","tests/test_refresh.py","tests/test_validator.py","tests/test_language_adapters.py"]
     message: "Centralized compact block-comment L1 parsing, preserved reduced headers, proved PHP imports are not exports, and removed LiteLLM initialization from zero-LLM commands. 296 tests pass; verify and doctor are clean."
+  - agent: "composer"
+    provider: "cursor"
+    date: "2026-09-06"
+    session_id: "s_20260906_issues467"
+    task: "Fix issues #4 #6 #7"
+    changed: ["codedna_tool/languages/php.py","codedna_tool/languages/base.py","codedna_tool/languages/vbnet.py","codedna_tool/languages/__init__.py","codedna_tool/cli.py","integrations/.roorules","integrations/install.sh","integrations/README.md","docs/languages.md","README.md","README-it.md","CHANGELOG.md","tests/test_issues_4_6_7.py","tests/test_docs.py"]
+    visited: ["codedna_tool/languages/php.py","codedna_tool/languages/base.py","codedna_tool/languages/csharp.py","codedna_tool/languages/__init__.py","codedna_tool/cli.py","integrations/.clinerules"]
+    message: "Validated #4/#6/#7 still open. Fixed PHP mixed-HTML injection + full-file has_codedna_header; added VbNetAdapter; added Roo --tools roo. 306 tests pass."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to CodeDNA will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **VB.NET language adapter (`.vb`)** — structural regex adapter with `'` comment headers, Public Class/Module/Sub/Function/Property exports, and Option/Imports-aware injection (issue #6).
+- **Roo Code install target** — `codedna install --tools roo` writes `.roorules` (issue #7).
+
+### Fixed
+
+- **PHP mixed HTML templates** — `inject_header` now inserts CodeDNA comments inside the first `<?php`/`<?=`/`<?` block (or wraps a new `<?php` block when none exists), so annotations are never HTML-visible. `has_codedna_header` no longer truncates at 16KB, preventing duplicate headers after large HTML prefixes (issue #4).
+
 ### Fixed
 
 - **`codedna refresh` no longer deletes source code below a single-line `/** … */` comment.** `parse_codedna_comment_header` entered block-comment mode on any line starting with `/**`/`/*` and only left it on a *later* line ending in `*/`, so a one-line JSDoc (`/** Map the band. */`) put the parser in block mode for the rest of the file. From there every code line was read as comment content: a template literal containing ` — ` became `first_line`, `agent: o.agent,` inside an object literal became the `agent` field, and `_header_end` landed ~100 lines into the file. `has_codedna_header()` then returned True for the un-annotated file (so `init` skipped it) and `refresh` replaced the whole phantom range — deleting the code. Reproduced on 8 TypeScript files in a real 770-file monorepo. Single-line block comments now close immediately. Regression test in `tests/test_refresh.py`.

--- a/README-it.md
+++ b/README-it.md
@@ -96,7 +96,7 @@ codedna check .                                # report di copertura
 codedna refresh .                              # aggiorna exports + used_by (zero costo LLM)
 ```
 
-> Linguaggi rilevati automaticamente — Python, PHP, TypeScript/JavaScript, Go, Java, Kotlin, Ruby, Rust, C# e Swift, oltre ai template supportati.
+> Linguaggi rilevati automaticamente — Python, PHP, TypeScript/JavaScript, Go, Java, Kotlin, Ruby, Rust, C#, VB.NET e Swift, oltre ai template supportati.
 > Il formato si adatta al linguaggio — PHP usa `//`, Python usa docstring, Blade usa `{{-- --}}`. Vedi [docs/languages.md](docs/languages.md).
 
 ### Riferimento comandi
@@ -128,7 +128,7 @@ codedna refresh .                              # aggiorna exports + used_by (zer
 | `codedna wiki sync <path>` | Rigenera `docs/codedna-wiki.md` — wiki narrativo di progetto a 7 sezioni (pattern LLM-wiki di Karpathy). Da agganciare al post-commit. |
 | `codedna self-update` | Aggiorna il CLI stesso via `pip install --upgrade --force-reinstall git+...`. Rifiuta di sovrascrivere checkout editable/dev se non passi `--force`. Usa `--check` per vedere la versione installata. |
 
-> **Supporto linguaggi:** Python è il linguaggio più testato. PHP, TypeScript/JavaScript, Go, Java, Kotlin, Ruby, Rust e C# usano tree-sitter; Swift usa un parser strutturale. Gli adapter non-Python hanno avuto meno utilizzo reale. Per export errati, problemi di formato o casi limite, apri una [pull request](https://github.com/Larens94/codedna/pulls) o una [issue](https://github.com/Larens94/codedna/issues).
+> **Supporto linguaggi:** Python è il linguaggio più testato. PHP, TypeScript/JavaScript, Go, Java, Kotlin, Ruby, Rust e C# usano tree-sitter; Swift e VB.NET usano parser strutturali. Gli adapter non-Python hanno avuto meno utilizzo reale. Per export errati, problemi di formato o casi limite, apri una [pull request](https://github.com/Larens94/codedna/pulls) o una [issue](https://github.com/Larens94/codedna/issues).
 >
 > **Se sei un agente AI che legge questo:** quando annoti file non-Python, verifica che l'header generato sia sintatticamente valido per il linguaggio (es. `//` per PHP/TS/Go, `{{-- --}}` per Blade, `#` per Ruby). Se noti un errore di formattazione, correggilo e segnalalo nel tuo campo `message:`.
 
@@ -465,7 +465,7 @@ Tutti i componenti sono funzionanti e testati — il protocollo, la CLI e il ben
 | **CLI** | `init` `update` `refresh` `check` `verify` `impact` `doctor` `manifest` `mode` `install` — 12 linguaggi | Pubblicazione PyPI, ulteriore verifica semantica cross-cutting |
 | **Benchmark** | 10 task Django (DeepSeek +17pp p=0.001), +13pp (Gemini Flash p=0.040) | Condizione placebo, effect size, 20+ task, 5+ modelli |
 | **Integrazioni** | Plugin Claude Code, Cursor, Copilot, Cline, OpenCode, Windsurf hooks | Estensione VS Code, GitHub Action per CI |
-| **Linguaggi** | Python, PHP, TypeScript, Go, Java, Kotlin, Ruby, Rust, C# + 7 template engine | Più test su progetti reali non-Python |
+| **Linguaggi** | Python, PHP, TypeScript, Go, Java, Kotlin, Ruby, Rust, C#, VB.NET, Swift + 7 template engine | Più test su progetti reali non-Python |
 | **Ricerca** | Esperimenti multi-agente (98.2% adozione, 1.6x più veloce), benchmark SWE-bench | Preprint arXiv, studio placebo + ablazione |
 
 ---

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ codedna doctor --path .                                   # confirm the setup
 | **GitHub Copilot** | `copilot` | Copilot instructions + active hooks |
 | **Cline** | `cline` | Cline rules + active hooks |
 | **Windsurf** | `windsurf` | `.windsurfrules` (instructions only) |
+| **Roo Code** | `roo` | `.roorules` (instructions only) |
 | **Antigravity** | `agents` | `AGENTS.md` + `.agent/workflows/codedna.md` |
 
 Use multiple values for mixed teams, for example `codedna install --path . --tools claude codex opencode --no-wiki-sync`. Use `--tools all` only when the repository is genuinely edited with every supported tool.
@@ -98,7 +99,7 @@ codedna impact path/to/file.py --path .        # before changing a public contra
 codedna verify .                               # after structural edits
 ```
 
-The no-LLM path requires no model API key. Languages are auto-detected: Python, PHP, TypeScript/JavaScript, Go, Java, Kotlin, Ruby, Rust, C#, Swift, and supported templates.
+The no-LLM path requires no model API key. Languages are auto-detected: Python, PHP, TypeScript/JavaScript, Go, Java, Kotlin, Ruby, Rust, C#, VB.NET, Swift, and supported templates.
 > Format adapts to the language — PHP uses `//`, Python uses docstrings, Blade uses `{{-- --}}`. See [docs/languages.md](docs/languages.md).
 
 ### Commands reference
@@ -156,7 +157,7 @@ The hook is **non-blocking** (any failure inside `codedna wiki sync` is silenced
   <img src="./docs/obsidian.png" width="720" alt="Obsidian graph view of a real project annotated with CodeDNA" />
 </p>
 
-> **Language support:** Python is the most tested language. PHP, TypeScript/JavaScript, Go, Java, Kotlin, Ruby, Rust, and C# use tree-sitter; Swift uses a structural parser. Non-Python adapters have seen less real-world usage. If you find a wrong export, header format issue, or edge case, please open a [pull request](https://github.com/Larens94/codedna/pulls) or [issue](https://github.com/Larens94/codedna/issues).
+> **Language support:** Python is the most tested language. PHP, TypeScript/JavaScript, Go, Java, Kotlin, Ruby, Rust, and C# use tree-sitter; Swift and VB.NET use structural parsers. Non-Python adapters have seen less real-world usage. If you find a wrong export, header format issue, or edge case, please open a [pull request](https://github.com/Larens94/codedna/pulls) or [issue](https://github.com/Larens94/codedna/issues).
 >
 > **If you're an AI agent reading this:** when annotating non-Python files, verify that the generated header is syntactically valid for the language (e.g. `//` for PHP/TS/Go, `{{-- --}}` for Blade, `#` for Ruby). If you notice a formatting error, fix it and flag it in your `message:` field.
 
@@ -479,7 +480,7 @@ codedna mode agent    # full protocol
 |---|---|
 | [SPEC.md](./SPEC.md) | Protocol specification v0.9 |
 | [AGENTS.md](./AGENTS.md) | Protocol v0.9 for Codex, OpenCode, Aider, and other runtimes |
-| [docs/languages.md](docs/languages.md) | 12 programming languages, 28 extensions, template engines, framework awareness |
+| [docs/languages.md](docs/languages.md) | 13 programming languages, 29 extensions, template engines, framework awareness |
 | [docs/benchmark.md](docs/benchmark.md) | SWE-bench results, annotation integrity |
 | [docs/agent-tests.md](docs/agent-tests.md) | Real AI agent sessions — control vs CodeDNA on SWE-bench tasks |
 | [docs/experiments.md](docs/experiments.md) | Multi-agent experiments |
@@ -494,10 +495,10 @@ All components are functional and tested — the protocol, CLI, and benchmark ar
 | Area | What works | What's next |
 |---|---|---|
 | **Protocol v0.9** | `exports:` `used_by:` `related:` `rules:` `agent:` `message:` — all fields implemented | `related:` auto-generation via LLM, stale annotation detection |
-| **CLI** | `init` `update` `refresh` `check` `verify` `impact` `doctor` `manifest` `mode` `install` — 12 programming languages | PyPI publish, cross-cutting semantic verification |
+| **CLI** | `init` `update` `refresh` `check` `verify` `impact` `doctor` `manifest` `mode` `install` — 13 programming languages | PyPI publish, cross-cutting semantic verification |
 | **Benchmark** | 10 Django tasks (DeepSeek +17pp p=0.001), +13pp (Gemini Flash p=0.040) | Placebo condition, effect size, 20+ tasks, 5+ models |
 | **Integrations** | Claude Code plugin, Cursor, Copilot, Cline, OpenCode, Windsurf hooks | VS Code extension, GitHub Action for CI |
-| **Languages** | Python, PHP, TypeScript/JavaScript, Go, Java, Kotlin, Ruby, Rust, C#, Swift + 7 template families | More real-world testing on non-Python projects |
+| **Languages** | Python, PHP, TypeScript/JavaScript, Go, Java, Kotlin, Ruby, Rust, C#, VB.NET, Swift + 7 template families | More real-world testing on non-Python projects |
 | **Research** | Multi-agent experiments (98.2% adoption, 1.6x speedup), SWE-bench benchmark | arXiv preprint, placebo + ablation study |
 
 ---

--- a/codedna_tool/cli.py
+++ b/codedna_tool/cli.py
@@ -39,7 +39,7 @@ Requires: ANTHROPIC_API_KEY env var (or --api-key) for Anthropic models.
 No API key needed for local models via Ollama (pip install 'codedna[litellm]').
 Provider priority: litellm (all providers) > anthropic (fallback, Claude only).
 Multi-language: pass --extensions ts go php rs java kt rb cs swift axl (or with dots).
-Supported: .ts .tsx .js .jsx .mjs | .go | .php | .rs | .java | .kt .kts | .rb | .cs | .swift | .axl
+Supported: .ts .tsx .js .jsx .mjs | .go | .php | .rs | .java | .kt .kts | .rb | .cs | .vb | .swift | .axl
 message:
 """
 
@@ -1969,6 +1969,7 @@ _TOOL_FILES = {
     "copilot":  ("copilot-instructions.md", ".github/copilot-instructions.md"),
     "cline":    (".clinerules",  ".clinerules"),
     "windsurf": (".windsurfrules", ".windsurfrules"),
+    "roo":      (".roorules", ".roorules"),
     "opencode": ("AGENTS.md",   "AGENTS.md"),
     "agents":   [("AGENTS.md", "AGENTS.md"),
                  (".agent/workflows/codedna.md", ".agent/workflows/codedna.md")],
@@ -2069,6 +2070,7 @@ for f in $STAGED; do
         kt|kts)            EXTS="$EXTS kt" ;;
         rb)                EXTS="$EXTS rb" ;;
         cs)                EXTS="$EXTS cs" ;;
+        vb)                EXTS="$EXTS vb" ;;
         swift|axl)         EXTS="$EXTS $ext" ;;
         j2|jinja2)         EXTS="$EXTS j2" ;;
         twig)              EXTS="$EXTS twig" ;;
@@ -2148,6 +2150,7 @@ def _detect_ai_tools(repo_root: Path) -> list[str]:
         "copilot":  [".github/copilot-instructions.md"],
         "cline":    [".clinerules", ".cline"],
         "windsurf": [".windsurfrules", ".windsurf"],
+        "roo":      [".roo", ".roorules"],
         "opencode": [".opencode"],
         # Antigravity uses .agent/ (singular) + GEMINI.md — see
         # https://antigravity.google/docs/rules-workflows
@@ -3269,7 +3272,7 @@ def main():
     )
     install_p.add_argument(
         "--tools", nargs="*", default=None,
-        help="AI tools: claude codex aider cursor copilot cline windsurf opencode agents, their supported *-hooks variants, or all (default: auto-detect). 'agents' installs the Antigravity workflow.",
+        help="AI tools: claude codex aider cursor copilot cline windsurf roo opencode agents, their supported *-hooks variants, or all (default: auto-detect). 'agents' installs the Antigravity workflow.",
     )
     install_p.add_argument("--skip-hook", action="store_true", help="Skip pre-commit hook installation")
     install_p.add_argument("--skip-prompt", action="store_true", help="Skip AI tool prompt installation")

--- a/codedna_tool/languages/__init__.py
+++ b/codedna_tool/languages/__init__.py
@@ -18,6 +18,7 @@ claude-sonnet-4-6 | anthropic | 2026-04-16 | s_20260416_001 | added tree-sitter 
 claude-opus-4-6 | anthropic | 2026-04-18 | s_20260418_gate6 | GATE 6: removed regex fallback — tree-sitter is now required for all source languages; regex adapters kept only as utility classes
 gpt-5 | openai | 2026-08-20 | s_20260820_hardening | restore advertised Rust, C#, and Swift registry support with executable tests
 gpt-5 | openai | 2026-08-21 | s_20260821_axl | register native .axl structured annotation support
+composer | cursor | 2026-09-06 | s_20260906_vbnet | register .vb VbNetAdapter (issue #6)
 message:
 """
 
@@ -31,6 +32,7 @@ from .jinja import JinjaAdapter
 from .razor import RazorAdapter
 from .vue import VueAdapter, SvelteAdapter
 from .swift import SwiftAdapter
+from .vbnet import VbNetAdapter
 from .axl import AxlAdapter
 
 # ── Tree-sitter adapters (required) ──────────────────────────────────────────
@@ -68,6 +70,7 @@ _REGISTRY: dict[str, LanguageAdapter] = {
     ".rs":    _rust_adapter,
     ".cs":    _csharp_adapter,
     ".swift": SwiftAdapter(),
+    ".vb":    VbNetAdapter(),  # structural regex (Swift precedent; no tree-sitter-vb on Linux)
     ".axl":   AxlAdapter(),
     # Template engines (regex-based by design)
     ".blade.php": BladeAdapter(),

--- a/codedna_tool/languages/base.py
+++ b/codedna_tool/languages/base.py
@@ -40,6 +40,7 @@ gpt-5 | openai | 2026-08-20 | s_20260820_hardening | document Rules contracts on
 gpt-5 | openai | 2026-08-21 | s_20260821_axl | add native structured-annotation extension points for AXL
 gpt-5 | openai | 2026-08-27 | s_20260827_header_parser | centralize comment-header parsing and accept compact PHPDoc/JSDoc blocks without leading stars
 claude-opus | anthropic | 2026-09-03 | s_20260903_singleline_block | single-line /** */ no longer leaves parse_codedna_comment_header in block mode (refresh deleted code)
+composer | cursor | 2026-09-06 | s_20260906_php_mixed | has_codedna_header scans full source (no 16KB cut) to prevent PHP mixed-file duplicates
 message:
 """
 
@@ -212,8 +213,10 @@ class LanguageAdapter(ABC):
                  and {# #} / {{-- --}} template blocks. Prevents duplicate headers
                  when re-running codedna init on already-annotated files.
                  Detects both full headers (exports:/used_by:) and reduced headers (rules:/agent:).
+                 Scan the FULL source — a 16KB truncation missed headers after large HTML
+                 prefixes in mixed PHP templates (issue #4), causing duplicate injection.
         """
-        return parse_codedna_comment_header(source[:16 * 1024], self.comment_prefix) is not None
+        return parse_codedna_comment_header(source, self.comment_prefix) is not None
 
     def parse_codedna_fields(self, source: str) -> dict[str, str] | None:
         """Parse native structured CodeDNA fields when comments are not the carrier.

--- a/codedna_tool/languages/php.py
+++ b/codedna_tool/languages/php.py
@@ -12,6 +12,7 @@ agent:   claude-sonnet-4-6 | anthropic | 2026-04-16 | s_20260416_005 | remove un
 claude-sonnet-4-6 | anthropic | 2026-04-18 | s_20260418_php | fix _resolve_use: lowercase-first candidate order + resolve() for real fs path — fixes macOS case-insensitive match returning App/ instead of app/ (Laravel PSR-4 convention)
 claude-sonnet-4-6 | anthropic | 2026-04-18 | s_20260418_php2 | GATE 3: add inject_function_rules() — injects PHPDoc Rules: above public methods; handles existing PHPDoc (append before */) and no-doc (new block)
 claude-opus-4-6 | anthropic | 2026-04-21 | s_20260421_codeql | remove unused regex globals _NAMESPACE_RE and _PHALCON_EXTENDS_RE (dead declarations) — CodeQL #1662, #1690
+composer | cursor | 2026-09-06 | s_20260906_php_mixed | issue #4: inject_header keeps annotations inside PHP tags for mixed HTML/PHP
 message:
 """
 
@@ -165,37 +166,43 @@ class PhpAdapter(LanguageAdapter):
 
     def inject_header(self, source: str, rel: str, exports: str, used_by: str,
                       rules: str, model_id: str, today: str) -> str:
-        """Prepend a CodeDNA // comment block. Returns source unchanged if already present.
+        """Insert a CodeDNA // comment block inside the first PHP open tag.
 
         Rules:   Must be idempotent — if has_codedna_header() returns True, return unchanged.
                  Header uses // comments, NOT /** PHPDoc */ — avoids IDE PHPDoc conflicts.
-                 The PHP opening tag (<?php) must remain the very first line of the file;
-                 CodeDNA block is inserted immediately after <?php on line 2.
-                 declare(strict_types=1) lines are preserved after the CodeDNA block.
+                 NEVER emit raw // comments into the HTML stream: mixed HTML/PHP templates
+                 (issue #4) must keep the annotation inside <?php … ?> so browsers do not
+                 render it. Insertion is immediately after the first <?php / <?= / <? tag
+                 anywhere in the file (not only at line start). If no PHP tag exists, wrap
+                 the header in a leading <?php … ?> block. declare(strict_types=1) on the
+                 same line as <?php stays after the header inside the PHP block.
         """
         if self.has_codedna_header(source):
             return source
 
         header_lines = self._build_header_lines(rel, exports, used_by, rules, model_id, today)
-        header = "\n".join(header_lines) + "\n"
+        header = "\n".join(header_lines)
 
-        lines = source.splitlines(keepends=True)
+        # Match <?php, <?=, or short <? but never <?xml
+        open_re = re.compile(r"<\?php|<\?=|<\?(?!xml)", re.IGNORECASE)
+        m = open_re.search(source)
+        if m is None:
+            # HTML-only / no PHP tag — wrap so // never becomes visible text.
+            return f"<?php\n{header}\n?>\n" + source
 
-        # Find insertion point: after <?php and optional declare(strict_types)
-        insert_idx = 0
-        for i, line in enumerate(lines):
-            stripped = line.strip()
-            if stripped.startswith("<?php") or stripped.startswith("<?PHP"):
-                insert_idx = i + 1
-                break
+        tag = m.group(0)
+        start, end = m.span()
+        if tag.lower() != "<?php":
+            # <?= or <?  — emit a dedicated <?php block before the short tag.
+            return source[:start] + f"<?php\n{header}\n?>\n" + source[start:]
 
-        # Skip blank lines right after <?php
-        while insert_idx < len(lines) and not lines[insert_idx].strip():
-            insert_idx += 1
-
-        before = "".join(lines[:insert_idx])
-        after = "".join(lines[insert_idx:])
-        return before + "\n" + header + "\n" + after
+        # <?php — splice header immediately after the opening tag (inside PHP).
+        rest = source[end:]
+        if rest.startswith("\r\n"):
+            rest = rest[2:]
+        elif rest.startswith("\n") or rest.startswith("\r"):
+            rest = rest[1:]
+        return source[:end] + "\n" + header + "\n" + rest
 
     def inject_function_rules(self, source: str, func: LangFuncInfo, rules_text: str) -> str:
         """Inject a PHPDoc Rules: block above a public PHP method.

--- a/codedna_tool/languages/vbnet.py
+++ b/codedna_tool/languages/vbnet.py
@@ -1,0 +1,149 @@
+"""vbnet.py — CodeDNA v0.9 adapter for VB.NET source files.
+
+exports: _CLASS_RE | _METHOD_RE | _PROP_RE | _IMPORTS_RE | class VbNetAdapter
+used_by: codedna_tool/languages/__init__.py → VbNetAdapter
+rules:   regex-based only — no .NET SDK or tree-sitter dependency required.
+Detects Public Class/Module/Interface/Structure/Enum and Public Sub/Function/Property.
+Type-qualified exports: Class::Member for public members.
+Friend/Private/Protected members are excluded (Friend ≈ C# internal).
+VB uses apostrophe (' ) comments — no docstring syntax.
+agent:   composer | cursor | 2026-09-06 | s_20260906_vbnet | issue #6: initial VB.NET LanguageAdapter (.vb, ' comments)
+message:
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from .base import LanguageAdapter, LangFileInfo
+
+# Case-insensitive: VB.NET keywords are not case-sensitive.
+_CLASS_RE = re.compile(
+    r"^\s*(?:Public\s+)?(?:Partial\s+|MustInherit\s+|NotInheritable\s+)*"
+    r"(?:Class|Module|Interface|Structure|Enum)\s+(\w+)",
+    re.MULTILINE | re.IGNORECASE,
+)
+_METHOD_RE = re.compile(
+    r"^\s+Public\s+(?:Shared\s+|Overridable\s+|Overrides\s+|MustOverride\s+|Async\s+)*"
+    r"(?:Sub|Function)\s+(\w+)\s*[\(\[]",
+    re.MULTILINE | re.IGNORECASE,
+)
+_PROP_RE = re.compile(
+    r"^\s+Public\s+(?:Shared\s+|ReadOnly\s+|WriteOnly\s+)*Property\s+(\w+)",
+    re.MULTILINE | re.IGNORECASE,
+)
+_IMPORTS_RE = re.compile(r"^Imports\s+([\w.]+)", re.MULTILINE | re.IGNORECASE)
+_OPTION_RE = re.compile(r"^Option\s+\w+", re.MULTILINE | re.IGNORECASE)
+
+
+class VbNetAdapter(LanguageAdapter):
+    """CodeDNA adapter for .vb files.
+
+    Rules:   Only Public members captured; Private/Protected/Friend are excluded.
+             Partial classes are treated as a single export entry.
+             Never raises — return LangFileInfo(parseable=False) on OSError.
+             comment_prefix is apostrophe (' ) — VB has no block-docstring syntax.
+    """
+
+    @property
+    def comment_prefix(self) -> str:
+        return "'"
+
+    def extract_info(self, path: Path, repo_root: Path) -> LangFileInfo:
+        """Parse a VB.NET source file and return structural information.
+
+        Rules:   Must never raise — return LangFileInfo(parseable=False) on any OSError.
+                 Public methods are listed as ClassName::Member.
+                 Properties are included as exports.
+                 Imports directives are captured but not resolved to file paths.
+        """
+        rel = str(path.relative_to(repo_root))
+        try:
+            source = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            return LangFileInfo(path=path, rel=rel, parseable=False)
+
+        list_str_exports: list[str] = []
+        cls_names: list[str] = []
+
+        for m in _CLASS_RE.finditer(source):
+            name = m.group(1)
+            if name not in cls_names:
+                cls_names.append(name)
+                list_str_exports.append(name)
+
+        cls_prefix = cls_names[0] + "::" if cls_names else ""
+
+        seen: set[str] = set(cls_names)
+        reserved = {
+            "class", "module", "interface", "structure", "enum",
+            "sub", "function", "property", "string", "integer", "boolean",
+            "object", "task",
+        }
+        for m in _METHOD_RE.finditer(source):
+            name = m.group(1)
+            if name in seen or name.lower() in reserved:
+                continue
+            entry = f"{cls_prefix}{name}"
+            if entry not in list_str_exports:
+                list_str_exports.append(entry)
+                seen.add(name)
+
+        for m in _PROP_RE.finditer(source):
+            name = m.group(1)
+            if name not in seen:
+                entry = f"{cls_prefix}{name}"
+                if entry not in list_str_exports:
+                    list_str_exports.append(entry)
+                    seen.add(name)
+
+        list_str_deps = [m.group(1) for m in _IMPORTS_RE.finditer(source)]
+
+        return LangFileInfo(
+            path=path,
+            rel=rel,
+            exports=list_str_exports,
+            deps=list_str_deps,
+            has_codedna=self.has_codedna_header(source),
+        )
+
+    def inject_header(self, source: str, rel: str, exports: str, used_by: str,
+                      rules: str, model_id: str, today: str) -> str:
+        """Prepend a CodeDNA ' comment block after Option/Imports, before types.
+
+        Rules:   Must be idempotent.
+                 Option Explicit/Strict/Infer/Compare and Imports stay at file top.
+                 CodeDNA block is inserted BEFORE Namespace / Public Class|Module|…
+                 — never inside a type body.
+                 If no Option/Imports, inserts at file top.
+        """
+        if self.has_codedna_header(source):
+            return source
+
+        header_lines = self._build_header_lines(rel, exports, used_by, rules, model_id, today)
+        header = "\n".join(header_lines) + "\n"
+
+        lines = source.splitlines(keepends=True)
+        insert_idx = 0
+        for i, line in enumerate(lines):
+            stripped = line.strip()
+            lower = stripped.lower()
+            if (
+                lower.startswith("option ")
+                or lower.startswith("imports ")
+                or not stripped
+                or stripped.startswith("'")
+            ):
+                insert_idx = i + 1
+            elif stripped.startswith("<"):  # attribute
+                continue
+            else:
+                break
+
+        before = "".join(lines[:insert_idx])
+        after = "".join(lines[insert_idx:])
+        before_norm = before.rstrip("\n")
+        after_norm = after.lstrip("\n")
+        separator = "\n\n" if before_norm else ""
+        return before_norm + separator + header + "\n" + after_norm

--- a/docs/install.html
+++ b/docs/install.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Install — CodeDNA</title>
-<meta name="description" content="Install CodeDNA for Claude Code, Codex, OpenCode, Aider, Cursor, Copilot, Cline, Windsurf and 12 programming languages.">
+<meta name="description" content="Install CodeDNA for Claude Code, Codex, OpenCode, Aider, Cursor, Copilot, Cline, Windsurf, Roo Code and 13 programming languages.">
 <link rel="icon" href="logo.png" type="image/png">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">

--- a/docs/languages.md
+++ b/docs/languages.md
@@ -1,6 +1,6 @@
 # Language Support
 
-CodeDNA v0.9 supports **12 programming languages** (counting TypeScript and JavaScript separately) across **28 registered extensions**, plus **7 template families**. All are auto-detected — no configuration needed.
+CodeDNA v0.9 supports **13 programming languages** (counting TypeScript and JavaScript separately) across **29 registered extensions**, plus **7 template families**. All are auto-detected — no configuration needed.
 
 | Language | Extensions | L1 | L2 | Parser | Framework awareness |
 |---|---|---|---|---|---|
@@ -13,6 +13,7 @@ CodeDNA v0.9 supports **12 programming languages** (counting TypeScript and Java
 | Ruby | `.rb` | ✅ | ✅ | tree-sitter | — |
 | Rust | `.rs` | ✅ | ✅ | tree-sitter | — |
 | C# | `.cs` | ✅ | ✅ | tree-sitter | — |
+| VB.NET | `.vb` | ✅ | ✅ | structural parser | — |
 | Swift | `.swift` | ✅ | ✅ | structural parser | — |
 | AXL *(experimental)* | `.axl` | ✅ | native symbol rules | native opcode frames | CodeDNA frames 80–86 |
 
@@ -34,7 +35,7 @@ AXL is intentionally different from comment-based adapters. `codedna init`, `ref
 
 ## What tree-sitter extracts
 
-Python uses the standard-library AST, PHP/TypeScript/JavaScript/Go/Java/Kotlin/Ruby/Rust/C# use tree-sitter, Swift uses its dedicated structural parser, and AXL uses native annotation/declaration frames. Together they provide:
+Python uses the standard-library AST, PHP/TypeScript/JavaScript/Go/Java/Kotlin/Ruby/Rust/C# use tree-sitter, Swift and VB.NET use dedicated structural parsers, and AXL uses native annotation/declaration frames. Together they provide:
 
 - **Exports**: classes, public methods (with full signatures), interfaces, traits, enums, constants
 - **Dependencies**: `use`, `import`, `require` statements resolved to file paths

--- a/integrations/.roorules
+++ b/integrations/.roorules
@@ -1,0 +1,92 @@
+# CodeDNA v0.9 — In-Source Communication Protocol
+# Setup: pipx install git+https://github.com/Larens94/codedna.git && codedna install --path . --tools roo --no-wiki-sync && codedna init . --no-llm
+
+This project uses CodeDNA. Every supported source file starts with a native CodeDNA header; Python uses a module docstring, while other languages use their valid comment syntax.
+
+On SESSION START:
+- Read `.codedna` at repo root — project map, last 3-5 agent_sessions entries
+- Run `codedna doctor --path .`; resolve errors before editing
+- CodeDNA is additive — it complements Roo Code's native memory, not replaces it
+
+On EDIT:
+- Before changing a public contract, run `codedna impact <file-or-symbol> --path .`
+- Re-read `rules:` before writing any logic — never violate these constraints
+- Read `Rules:` in function docstrings before writing logic there
+- Check `used_by:` after changes and update callers if needed
+- If you discover a constraint or fix a bug, add it to `rules:` for the next agent
+- Append a new `agent:` line to the module docstring after editing. Keep only the last 5 entries — drop the oldest if adding a 6th. Full history is in git and `.codedna`.
+
+On CREATE:
+- Write module docstring before any imports (exports/used_by/rules/agent)
+- Every public function **must** have a `Rules:` docstring
+- Use semantic naming: `list_dict_users_from_db = get_users()`
+
+## Writing good `rules:`
+
+`rules:` must be **specific and actionable** — never vague.
+
+```python
+# ✅ Good rules:
+rules:   get_invoices() returns ALL tenants — caller MUST filter is_suspended() before aggregating
+rules:   amount is in cents not euros — divide by 100 before display
+rules:   soft-delete via deleted_at — NEVER use DELETE, always SET deleted_at = NOW()
+
+# ❌ Bad rules:
+rules:   handle errors gracefully
+rules:   follow best practices
+rules:   none  ← when there ARE constraints but nobody wrote them
+```
+
+Update rules: every time you discover a constraint, fix a bug, or notice a non-obvious behavior.
+
+## Writing critical functions
+
+Every public function **must** have a `Rules:` docstring:
+
+```python
+def my_function(arg: type) -> return_type:
+    """Short description.
+
+    Rules:   What the agent MUST or MUST NOT do here.
+    message: model-id | YYYY-MM-DD | observation for next agent
+    """
+```
+
+## Inline annotations on complex logic
+
+When writing or editing code blocks with non-obvious logic, add a `# Rules:` or `# message:` comment above the block:
+
+```python
+# Rules: skip cancelled orders — status=4 means cancelled in legacy DB
+active = [o for o in orders if o.status != 4]
+
+# message: exchange rate uses daily rate, not real-time
+amount = order.amount * get_exchange_rate(order.currency)
+```
+
+When to add: business-rule conditionals, loops with filtering, algorithm steps where order matters, edge cases.
+When NOT to add: simple getters, obvious control flow, standard library usage.
+
+`message:` field (v0.8) — use for open observations not yet certain enough to become `rules:`:
+- In module docstring: `message: "<hypothesis or note for the next agent>"`
+- In function docstring: `message: <model-id> | <date> | <open observation>`
+- Lifecycle: promote to `rules:` or dismiss. Always append-only — never delete.
+
+On SESSION END:
+- Run `codedna verify .`; if stale, review evidence, run `codedna refresh .`, then verify again
+- Use `codedna session append` with agent, provider, session-id, task, changed, visited, and message; never edit `agent_sessions:` manually
+- Commit with AI git trailers: AI-Agent, AI-Provider, AI-Session, AI-Visited, AI-Message
+
+`exports:` are contracts — never rename without explicit instruction and updating all `used_by:` callers.
+
+Module docstring format:
+```
+"""filename.py — <purpose ≤15 words>.
+
+exports: fn(args) -> type
+used_by: consumer.py → fn
+rules:   <hard constraint>
+agent:   <model-id> | <provider> | <YYYY-MM-DD> | <session_id> | <what you did and noticed>
+         message: "<open hypothesis>"
+"""
+```

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -22,6 +22,7 @@ The curl installer shown in the tool-specific sections is a legacy fallback for 
 | **Cline** | **`cline-hooks`** | **`.clinerules` + hook scripts in `.clinerules/hooks/`** | ✅ Active (v3.36+) |
 | **OpenCode** | **`opencode`** | **`AGENTS.md` + `.opencode/plugins/codedna.js`** | ✅ Active |
 | Windsurf | `windsurf` | `.windsurfrules` | ⚠️ Instructions only |
+| Roo Code | `roo` | `.roorules` | ⚠️ Instructions only |
 | **Antigravity** | `agents` | **`AGENTS.md` + `.agent/workflows/codedna.md`** | ⚠️ Instructions only |
 | Aider | `aider` | `AGENTS.md` loaded with `--read` | ⚠️ Instructions + Git pre-commit gate |
 
@@ -202,6 +203,14 @@ Installs `.clinerules` + enforcement hooks in `.clinerules/hooks/` — Cline run
 
 ---
 
+## Roo Code
+
+```bash
+codedna install --path . --tools roo --no-wiki-sync
+```
+
+Installs `.roorules` in your repo root — Roo Code loads it as project custom instructions (fallback path; equivalent in spirit to Cline/Windsurf rule files).
+
 ## Windsurf (Codeium)
 
 ```bash
@@ -299,7 +308,7 @@ Note: Antigravity uses `.agent/` (singular), **not** `.agents/`. See the [offici
 | No session audit trail | Agent writes `.codedna` entry at end | Hook reminds at stop, blocks commit without AI trailers |
 
 **Tools with active enforcement (hooks):** Claude Code, Cursor (v1.7+), GitHub Copilot, Cline (v3.36+), OpenCode
-**Tools with instructions only:** Windsurf, Aider, Antigravity
+**Tools with instructions only:** Windsurf, Roo Code, Aider, Antigravity
 
 ---
 

--- a/integrations/install.sh
+++ b/integrations/install.sh
@@ -14,7 +14,7 @@
 #   1. pip install codedna  — CLI tool with 11 programming languages + templates
 #   2. codedna install      — pre-commit hook + AI tool prompt + .codedna manifest
 #
-# Supported AI tools: claude codex aider cursor copilot cline windsurf opencode agents (+ hook variants)
+# Supported AI tools: claude codex aider cursor copilot cline windsurf roo opencode agents (+ hook variants)
 # Supported languages: Python, TypeScript, JavaScript, Go, PHP, Java, Kotlin, Ruby, Rust, C#, Swift
 
 set -euo pipefail
@@ -59,6 +59,7 @@ do_cursor()   { curl -fsSL "$RAW/.cursorrules"             > "$REPO_ROOT/.cursor
 do_copilot()  { mkdir -p "$REPO_ROOT/.github"; curl -fsSL "$RAW/copilot-instructions.md" > "$REPO_ROOT/.github/copilot-instructions.md"; echo "  OK  GitHub Copilot -> .github/copilot-instructions.md"; }
 do_cline()    { curl -fsSL "$RAW/.clinerules"              > "$REPO_ROOT/.clinerules";                        echo "  OK  Cline          -> .clinerules"; }
 do_windsurf() { curl -fsSL "$RAW/.windsurfrules"           > "$REPO_ROOT/.windsurfrules";                     echo "  OK  Windsurf       -> .windsurfrules"; }
+do_roo()      { curl -fsSL "$RAW/.roorules"                > "$REPO_ROOT/.roorules";                          echo "  OK  Roo Code       -> .roorules"; }
 do_agents() {
     # Antigravity v1.20.3+ reads AGENTS.md (cross-vendor, always-on) from repo root
     # AND .agent/ (singular) for workflows. See: https://antigravity.google/docs/rules-workflows
@@ -198,6 +199,7 @@ case "$TOOL" in
     copilot)        do_copilot ;;
     cline)          do_cline ;;
     windsurf)       do_windsurf ;;
+    roo)            do_roo ;;
     agents)         do_agents ;;
     opencode)       do_opencode ;;
     claude-hooks)   do_claude; do_claude_hooks ;;
@@ -205,7 +207,7 @@ case "$TOOL" in
     copilot-hooks)  do_copilot; do_copilot_hooks ;;
     cursor-hooks)   do_cursor; do_cursor_hooks ;;
     opencode-hooks) do_opencode; do_opencode_hooks ;;
-    all)            do_claude; do_cursor; do_copilot; do_cline; do_windsurf; do_agents; do_opencode; do_claude_hooks; do_cline_hooks; do_copilot_hooks; do_cursor_hooks; do_opencode_hooks ;;
+    all)            do_claude; do_cursor; do_copilot; do_cline; do_windsurf; do_roo; do_agents; do_opencode; do_claude_hooks; do_cline_hooks; do_copilot_hooks; do_cursor_hooks; do_opencode_hooks ;;
     *) echo "Usage: install.sh [claude|codex|aider|claude-hooks|cursor|cursor-hooks|copilot|copilot-hooks|cline|cline-hooks|windsurf|opencode|opencode-hooks|agents|all]"; exit 1 ;;
 esac
 

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -40,8 +40,8 @@ def test_public_docs_share_canonical_product_facts() -> None:
     assert "C/C++" not in spec
 
     languages = _read("docs/languages.md")
-    assert "12 programming languages" in languages
-    assert "28 registered extensions" in languages
+    assert "13 programming languages" in languages
+    assert "29 registered extensions" in languages
     assert "AXL *(experimental)*" in languages
     assert "7 template families" in languages
 

--- a/tests/test_issues_4_6_7.py
+++ b/tests/test_issues_4_6_7.py
@@ -1,0 +1,95 @@
+"""Regression tests for issues #4 (PHP mixed), #6 (VB.NET), #7 (Roo Code)."""
+
+from __future__ import annotations
+
+from codedna_tool.cli import _TOOL_FILES, _detect_ai_tools
+from codedna_tool.languages import SUPPORTED_EXTENSIONS, get_adapter
+
+
+class TestIssue4PhpMixedHtml:
+    def test_same_line_php_keeps_header_inside_tags(self):
+        php = get_adapter(".php")
+        src = "<!DOCTYPE html>\n<html>\n<?php include 'x.php'; ?>\n</html>\n"
+        out = php.inject_header(src, "header.php", "none", "none", "none", "test", "2026-09-06")
+        assert out.startswith("<!DOCTYPE html>")
+        open_at = out.lower().index("<?php")
+        exports_at = out.index("exports:")
+        close_at = out.index("?>", open_at)
+        assert open_at < exports_at < close_at
+        assert out.count("exports:") == 1
+        assert php.inject_header(out, "header.php", "none", "none", "none", "test", "2026-09-06") == out
+
+    def test_midline_php_keeps_header_inside_tags(self):
+        php = get_adapter(".php")
+        src = "<title><?php echo $t; ?></title>\n"
+        out = php.inject_header(src, "t.php", "none", "none", "none", "test", "2026-09-06")
+        assert out.startswith("<title><?php")
+        assert "exports:" in out
+        open_at = out.lower().index("<?php")
+        exports_at = out.index("exports:")
+        close_at = out.index("?>", open_at)
+        assert open_at < exports_at < close_at
+
+    def test_html_only_wraps_php_block(self):
+        php = get_adapter(".php")
+        src = "<!DOCTYPE html><html></html>\n"
+        out = php.inject_header(src, "t.php", "none", "none", "none", "test", "2026-09-06")
+        assert out.startswith("<?php")
+        assert "?>" in out
+        assert out.index("exports:") < out.index("?>")
+        assert "<!DOCTYPE html>" in out[out.index("?>") :]
+
+    def test_large_html_prefix_does_not_duplicate(self):
+        php = get_adapter(".php")
+        annotated = (
+            "<!-- pad -->\n" * 2000
+            + "<?php\n"
+            + "// Foo.php — x.\n//\n// exports: none\n// used_by: none\n"
+            + "// rules:   none\n// agent:   t | codedna-cli | 2026-09-06 | s | n\n"
+            + "// message: \nclass Foo {}\n"
+        )
+        assert php.has_codedna_header(annotated) is True
+        out = php.inject_header(annotated, "Foo.php", "none", "none", "none", "test", "2026-09-06")
+        assert out.count("exports:") == 1
+
+
+class TestIssue6VbNet:
+    def test_registered_and_extracts_public_members(self, tmp_path):
+        assert ".vb" in SUPPORTED_EXTENSIONS
+        vb = get_adapter(".vb")
+        p = tmp_path / "UserService.vb"
+        p.write_text(
+            "Option Strict On\n"
+            "Imports System\n\n"
+            "Public Class UserService\n"
+            "    Public Function GetUser(id As Integer) As String\n"
+            "        Return \"u\"\n"
+            "    End Function\n"
+            "    Private Sub Hidden()\n"
+            "    End Sub\n"
+            "    Public Property Name As String\n"
+            "End Class\n"
+        )
+        info = vb.extract_info(p, tmp_path)
+        assert "UserService" in info.exports
+        assert any("GetUser" in e for e in info.exports)
+        assert not any("Hidden" in e for e in info.exports)
+
+    def test_inject_after_imports_idempotent(self):
+        vb = get_adapter(".vb")
+        source = (
+            "Option Explicit On\nImports System\n\n"
+            "Public Module Program\n    Public Sub Main()\n    End Sub\nEnd Module\n"
+        )
+        r1 = vb.inject_header(source, "Program.vb", "Program", "none", "none", "test", "2026-09-06")
+        assert r1.index("Imports System") < r1.index("exports:") < r1.index("Public Module")
+        assert vb.inject_header(r1, "Program.vb", "Program", "none", "none", "test", "2026-09-06") == r1
+
+
+class TestIssue7RooCode:
+    def test_tool_files_and_detection(self, tmp_path):
+        assert "roo" in _TOOL_FILES
+        assert _TOOL_FILES["roo"] == (".roorules", ".roorules")
+        (tmp_path / ".roorules").write_text("# roo\n")
+        detected = _detect_ai_tools(tmp_path)
+        assert "roo" in detected

--- a/tests/test_language_adapters.py
+++ b/tests/test_language_adapters.py
@@ -657,7 +657,7 @@ class TestFallback:
 
     def test_advertised_languages_are_registered(self):
         """README-advertised C#, Rust, and Swift adapters must be callable."""
-        for ext in [".cs", ".rs", ".swift"]:
+        for ext in [".cs", ".rs", ".swift", ".vb"]:
             assert get_adapter(ext) is not None, f"{ext} should be registered"
 
     def test_unsupported_extension_returns_none(self):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Validates and implements the three open issues that have been idle since April.

## Validation

| Issue | Verdict | Notes |
|---|---|---|
| **#4** PHP duplicates + mixed HTML | Still valid (partially) | Pure-PHP re-init was already idempotent. Mixed HTML/`<?php … ?>` on one line still put `//` comments **outside** PHP (browser-visible). Headers after a >16KB HTML prefix could also be missed, causing duplicates. |
| **#6** VB.NET adapter | Valid feature request | No `.vb` adapter existed. Regex/structural adapter is the right MVP (Swift precedent; no reliable Linux `tree-sitter-vb` wheel). |
| **#7** Roo Code integration | Valid feature request | Zero Roo support; Cline/Windsurf-class instructions-only install is enough for v1. |

## Changes

### #4 — PHP mixed templates
- `PhpAdapter.inject_header` inserts inside the first `<?php` / `<?=` / `<?` tag (or wraps a leading `<?php` block when none exists).
- `LanguageAdapter.has_codedna_header` scans the full file (no 16KB cut).

### #6 — VB.NET
- New `VbNetAdapter` for `.vb` with `'` comments, Public Class/Module/Sub/Function/Property exports, Option/Imports-aware injection.
- Registered as structural adapter (29 extensions / 13 languages).

### #7 — Roo Code
- `codedna install --tools roo` writes `.roorules`.
- Detects `.roo` / `.roorules`; documented in README + integrations.

## Tests
- Full suite: **306 passed**
- New regressions in `tests/test_issues_4_6_7.py`

Fixes #4
Fixes #6
Fixes #7

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a068a2-e8a2-7e78-b13f-ab7d8886cebc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a068a2-e8a2-7e78-b13f-ab7d8886cebc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

